### PR TITLE
docs: clarify cloud provider support

### DIFF
--- a/src/multiplayer-servers/getting-started/cloud-provider-setup.md
+++ b/src/multiplayer-servers/getting-started/cloud-provider-setup.md
@@ -1,7 +1,10 @@
 ## Configuring your Cloud Provider
 
-This document describes the steps required to set up your Cloud provider for use with GameFabric. Support is 
-currently limited to Google Cloud.
+This document describes the steps required to set up your Cloud provider for use with GameFabric. Currently supported
+Cloud providers are Google Cloud, Azure, and AWS.
+
+Public documentation is currently limited to Google Cloud. For setup instructions for other Cloud providers, please
+contact your Nitrado Account Manager.
 
 ## Google Cloud
 

--- a/src/multiplayer-servers/getting-started/cloud-provider-setup.md
+++ b/src/multiplayer-servers/getting-started/cloud-provider-setup.md
@@ -1,7 +1,7 @@
 ## Configuring your Cloud Provider
 
 This document describes the steps required to set up your Cloud provider for use with GameFabric. Currently supported
-Cloud providers are Google Cloud, Azure, and AWS.
+Cloud providers are Google Cloud (GCP), Azure, and Amazon Web Services (AWS).
 
 Public documentation is currently limited to Google Cloud. For setup instructions for other Cloud providers, please
 contact your Nitrado Account Manager.


### PR DESCRIPTION
Adds clarification that public documentation is limited to Google Cloud, but Azure and AWS are also supported.