### PR TITLE
style: adjust increase color contrast for tips

### DIFF
--- a/.vitepress/theme/custom.css
+++ b/.vitepress/theme/custom.css
@@ -14,6 +14,11 @@
     --vp-c-brand-4: #ccac36;
     --vp-button-brand-bg: unset;
     --vp-button-brand-border: #ccac36;
+
+    --vp-c-tip-1: var(--vp-c-yellow-1);
+    --vp-c-tip-2: var(--vp-c-yellow-2);
+    --vp-c-tip-3: var(--vp-c-yellow-3);
+    --vp-c-tip-soft: var(--vp-c-yellow-soft);
 }
 
 


### PR DESCRIPTION
Fixes the contrast ratio for github like tips:

![Screenshot from 2025-01-30 13-26-12](https://github.com/user-attachments/assets/1f130c48-c020-44a1-b443-375d963d9466)
