### PR TITLE
style(api-specs): adjust tab background for dark mode

### DIFF
--- a/src/api/components/OpenAPI.vue
+++ b/src/api/components/OpenAPI.vue
@@ -99,7 +99,9 @@ onUnmounted(() => {
 .dark, :deep(tbody > tr > td > div ) {
     background:var(--vp-c-bg) !important;
 }
-
+.dark, :deep(.react-tabs__tab--selected) {
+  background: rgba(57, 57, 55, 0.4) !important;
+}
 #redocly {
   background-color: #fff;
   height: 100%;


### PR DESCRIPTION
Adjusts the background color for active tabs in the api spec: 

![Screenshot from 2025-02-05 15-20-34](https://github.com/user-attachments/assets/d7a655d2-d461-4ec2-b008-1764ebd23828)
