### PR TITLE
docs: add image retention policy explanation

### DIFF
--- a/src/multiplayer-servers/getting-started/pushing-container-images.md
+++ b/src/multiplayer-servers/getting-started/pushing-container-images.md
@@ -20,6 +20,15 @@ In case you haven't already done so, there are two options available to you:
 - **Add default Branches**: This will create two branches, "Production" and "Development", with default Image Retention Policies. Don't worry - you can always change the display names and policies later. See how to [edit a branch](edit-a-branch.md).
 - **Create Branch**: This will allow you to create a custom branch with a name and an Image Retention Policy of your choice.
 
+::: warning Image Retention Policy
+The Image Retention Policy defines how long images are stored in the registry and how many tags are retained.
+The default settings for the **Production** branch are 30 days and 10 tags. **Development** and **Custom** branches have default settings of **14 days** and **10 tags**. _These default settings can be adjusted for any branch._
+
+For example, with **Keep Days** set to 14 and **Keep Count** set to 10, images older than 14 days will be deleted, but the process stops if removing an image would leave fewer than 10 images.
+
+_Note: Either **Keep Days** or **Keep Count** (or both) must be >0. Setting **Keep Days** or **Keep Count** to *0* means that specific rule will be ignored._
+:::
+
 ### Add default Branches
 ::: info
 This option is only available if you have not created any branches yet.


### PR DESCRIPTION
Adds an explanation about the image retention policy as discussed and reviewed by product.