### PR TITLE
Explicitly document that game servers are only protected from termination in the allocated state

### DIFF
--- a/src/multiplayer-servers/getting-started/using-the-agones-sdk.md
+++ b/src/multiplayer-servers/getting-started/using-the-agones-sdk.md
@@ -45,7 +45,7 @@ wait for an allocation to happen.
 ### Allocate()
 
 This call signals to the hosting environment that the game server is in use and should not
-be shut down.
+be shut down. **In any other state the game server might be terminated at any time for scaling or other operational reasons.**
 
 You generally only need to call Allocate() yourself in one of two cases:
 


### PR DESCRIPTION
This adds documentation that explicitly explains that only allocated game servers are protected from termination and that game servers can be terminated at any time in all other states.