### PR TITLE
docs: add Dynamic Fleets and Persistent Servers terminology

### DIFF
--- a/src/multiplayer-servers/architecture/identifying-your-hosting-model.md
+++ b/src/multiplayer-servers/architecture/identifying-your-hosting-model.md
@@ -1,13 +1,13 @@
 # Identifying your Hosting Model
 
-GameFabric supports two major hosting models.
+GameFabric supports two major hosting models, reflected in the UI as **Persistent Servers** and **Dynamic Fleets**.
 
-- **Formations** are intended for long-running game servers that have game or player progression associated with them.
+- **Formations** (under **Persistent Servers** in the UI) are intended for long-running game servers that have game or player progression associated with them.
   Typically, players are given the ability to return to a specific game server, for example by selecting it from a
   server list. Each game server is usually associated with one or more unique properties, such as the name under
   which they are listed within the server list. Game servers like this are sometimes referred to as **Named Instances**
   or **Persistent Worlds**.
-- **Armadas** are the ideal choice for match-based or session-based game servers. For these games, typically a
+- **Armadas** (under **Dynamic Fleets** in the UI) are the ideal choice for match-based or session-based game servers. For these games, typically a
   matchmaking mechanism decides that a set of players should play together on one server. The matchmaker, or a similar
   service, then _allocates_ a game server for that play session and, once the session is over, the game server shuts
   down. The number of available game servers is dynamically adjusted based on demand.
@@ -25,6 +25,10 @@ are scaled up when needed, and scaled down again later. Each approach has its ow
 outlined in more detail in the following sections.
 
 ## Formations
+
+::: info UI Navigation
+Formations and Vessels are located under **Persistent Servers** in the GameFabric UI sidebar.
+:::
 
 Formations consist of **Vessels**, with each Vessel representing an individual game server that players can connect to.
 Vessels share a number of properties with the Formation that they belong to — such as the CPU and RAM resource
@@ -49,6 +53,10 @@ start, especially when scaling to Cloud. Formations are therefore not suited to 
 throughout the day. This is the purpose of Armadas.
 
 ## Armadas
+
+::: info UI Navigation
+ArmadaSets and Armadas are located under **Dynamic Fleets** in the GameFabric UI sidebar.
+:::
 
 Armadas automatically adjust the number of game servers within a given Region based on demand. To always be able to
 meet that demand, game servers are started in advance, and once they are ready to accept players, entered into a pool

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -29,13 +29,13 @@ It can have multiple [revisions](/multiplayer-servers/getting-started/glossary#r
 
 Revisions are kept track of in order to allow you to roll back to a previous revision, as well as manage multiple revisions running in parallel (for example during a rollout upgrade)
 
-See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
+Armadas are part of the [Dynamic Fleets](#dynamic-fleets) category in the UI. See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
 
 ## ArmadaSet
 
 An ArmadaSet is the configuration for a set of Armadas that share the same Fleet template and automatic scaling strategy.
 
-See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
+ArmadaSets are part of the [Dynamic Fleets](#dynamic-fleets) category in the UI. See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
 
 ## Branch
 
@@ -89,6 +89,12 @@ Dynamic Buffer is currently in Alpha.
 
 See [Dynamically configuring the buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer#dynamically-configuring-the-buffer-size-alpha) for details.
 
+## Dynamic Fleets
+
+Dynamic Fleets is the UI category for session-based or match-based game server hosting. It contains [ArmadaSets](#armadaset) and [Armadas](#armada), which automatically scale game server capacity based on demand.
+
+See [Identifying your Hosting Model](/multiplayer-servers/architecture/identifying-your-hosting-model) for guidance on choosing between Dynamic Fleets and [Persistent Servers](#persistent-servers).
+
 ## Environment
 
 Environments are a mechanism for isolating groups of resources. Resource names must be unique within each environment, but not across environments.
@@ -108,7 +114,7 @@ This resource is always managed by an Armada, and can't be configured through th
 A Formation acts as a template for individual game servers (Vessels) spawned within it.
 Vessels inherit all properties from their respective Formation, but environment variables and command line arguments can be overridden on a per-vessel basis.
 
-See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
+Formations are part of the [Persistent Servers](#persistent-servers) category in the UI. See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
 
 ## GameFabric Cloud
 
@@ -155,6 +161,12 @@ See [Editing Permissions](/multiplayer-servers/authentication/editing-permission
 ## Permission
 
 See [Editing Permissions](/multiplayer-servers/authentication/editing-permissions).
+
+## Persistent Servers
+
+Persistent Servers is the UI category for long-running game servers that have game or player progression associated with them. It contains [Formations](#formation) and [Vessels](#vessel), which allow custom configuration per individual game server.
+
+See [Identifying your Hosting Model](/multiplayer-servers/architecture/identifying-your-hosting-model) for guidance on choosing between Persistent Servers and [Dynamic Fleets](#dynamic-fleets).
 
 ## Pod
 
@@ -273,7 +285,7 @@ See also [SteelShield docs](/steelshield/gamefabric/gamefabric#managing-protocol
 A Vessel is a single **named** game server instance. It can, but doesn't have to be part of a [Formation](#formation).
 Each Vessel can be configured completely independently.
 
-See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
+Vessels are part of the [Persistent Servers](#persistent-servers) category in the UI. See also [hosting model](/multiplayer-servers/architecture/identifying-your-hosting-model).
 
 ## Wrapper
 


### PR DESCRIPTION
## Summary

- Add **Dynamic Fleets** and **Persistent Servers** as new glossary entries to match the redesigned GameFabric UI sidebar categories
- Update existing glossary entries (Armada, ArmadaSet, Formation, Vessel) with cross-references to the new UI category names
- Update the "Identifying your Hosting Model" page to introduce the new terminology in the intro and add UI navigation hints to each section

## Context

The new UI design groups sidebar navigation into two categories:

| UI category | Contains |
|---|---|
| **Dynamic Fleets** | ArmadaSets, Armadas |
| **Persistent Servers** | Formations, Vessels |

These terms had zero presence in the docs ("Dynamic Fleets" appeared nowhere; "Persistent Servers" only had 2 incidental mentions). Users seeing these categories in the UI would have no way to find them in the documentation.

## Changes

### `src/multiplayer-servers/getting-started/glossary.md`
- New **Dynamic Fleets** entry (alphabetically placed between Dynamic Buffer and Environment)
- New **Persistent Servers** entry (alphabetically placed between Permission and Pod)
- Updated **Armada**, **ArmadaSet**, **Formation**, **Vessel** entries to reference their UI category

### `src/multiplayer-servers/architecture/identifying-your-hosting-model.md`
- Updated intro paragraph to mention both UI category names
- Added `(under **Persistent Servers** in the UI)` / `(under **Dynamic Fleets** in the UI)` to bullet points
- Added `::: info UI Navigation` callout boxes to Formations and Armadas sections

## Notes

- Build could not be verified locally (missing corepack/rollup native deps). Changes are Markdown-only.
- This is the first in a series of PRs to align docs with the UI redesign.