### PR TITLE
docs: clarify uid 1000 enforcement via pod security context

### DIFF
--- a/src/multiplayer-servers/getting-started/building-a-container-image.md
+++ b/src/multiplayer-servers/getting-started/building-a-container-image.md
@@ -60,8 +60,8 @@ A Dockerfile is a text document that contains the commands a user could call on 
 For example, this typically includes fetching dependencies required to run the binary, configuring the environment, settings permissions
 on certain folders or just copying and moving files.
 
-::: warning Container User
-Container users are currently restricted to using `uid` 1000, as shown in the example below. See [Quotas](/multiplayer-servers/multiplayer-services/quotas#user-id) for more details.
+::: warning Container user
+GameFabric enforces uid 1000 via the Kubernetes pod security context (`runAsUser: 1000`). The container process always runs as uid 1000, regardless of the `USER` instruction in the Dockerfile. Your Dockerfile should create a user with uid 1000 and ensure all files the game server needs are owned by or readable by that user. See [Quotas](/multiplayer-servers/multiplayer-services/quotas#user-id) for more details.
 :::
 
 Here is an example, where this Dockerfile builds an image that runs the game server:
@@ -96,8 +96,9 @@ CMD ["/app/gameserver"]
    Additionally, install anything that is required to run the game server binary.
    Keep in mind that this is a blank system, without pre-installed custom libraries.
 
-3. Make sure the game server binary is in a separate folder within the Docker image,
-   configured to be owned by a custom Linux user and group that is allowed to execute it.
+3. Create a user with uid 1000 and set up a working directory owned by that user.
+   GameFabric runs the container process as uid 1000 via the pod security context,
+   so file ownership must match to avoid permission errors at runtime.
 
 4. The game server binary should already be compiled and is then copied from your machine to the Docker image when it is built.
 

--- a/src/multiplayer-servers/getting-started/quickstart.md
+++ b/src/multiplayer-servers/getting-started/quickstart.md
@@ -31,7 +31,7 @@ Package your game server into a Docker container. A minimal Dockerfile might loo
 ```Dockerfile
 FROM ubuntu:22.04
 
-# Create a non-root user with uid 1000 as required by GameFabric
+# Create a non-root user with uid 1000 (enforced by GameFabric's pod security context)
 RUN groupadd -g 1000 game && useradd -u 1000 -g 1000 -m game
 
 COPY gameserver /app/gameserver

--- a/src/multiplayer-servers/multiplayer-services/quotas.md
+++ b/src/multiplayer-servers/multiplayer-services/quotas.md
@@ -25,10 +25,12 @@ This page lists all known system limitations that developers should be aware of 
 
 ### User ID
 
-- **Limit**: uid 1000 required
-- **Description**: Container users are currently restricted to using `uid` 1000. This must be configured in your Dockerfile when creating container images.
+- **Limit**: uid 1000 enforced via pod security context
+- **Description**: GameFabric sets `runAsUser: 1000` in the Kubernetes pod security context. This means the container process always runs as uid 1000, regardless of the `USER` instruction in the Dockerfile.
 
-::: tip Container Image Setup
+To avoid file permission issues, create a user with uid 1000 in your Dockerfile and ensure all files the game server needs are owned by or readable by uid 1000. If the Dockerfile creates files owned by a different uid, the process may not be able to access them at runtime.
+
+::: tip Container image setup
 When building your container images, make sure to configure the user as shown in the [Building a Container Image](/multiplayer-servers/getting-started/building-a-container-image) guide.
 :::
 


### PR DESCRIPTION
## Summary

- Clarify that GameFabric enforces uid 1000 via the Kubernetes pod security
  context (`runAsUser: 1000`), not the Dockerfile `USER` instruction
- Explain the practical implication: file ownership in the image must match
  uid 1000, otherwise the process may not be able to access files at runtime
- Update quotas.md, building-a-container-image.md, and quickstart.md for
  consistency