### PR TITLE
docs: add Armada scaling overview page

### DIFF
--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -186,12 +186,15 @@ A Region is typically a geographic area made up of one or more [Locations](#loca
 
 It has to be defined on a per-[environment](#environment) basis.
 
+A Region contains at least one [Region Type](#region-type) that classifies its infrastructure, for example bare-metal and cloud. Region Types control how game servers are distributed and scaled across the Locations of the Region.
+
 While defining, you can assign a custom priority to each location. This priority determines which location will be filled first.
 
 ## Region Type
 
 A Region Type defines a class of infrastructure (for example, bare-metal or cloud) within a [Region](#region).
 Each Region Type has its own scaling parameters, and an [Armada](#armada) can have multiple Region Types per Region to balance cost and availability.
+When using the allocator, the Region Type priority determines which type is filled first.
 
 ## Replica
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -188,6 +188,11 @@ It has to be defined on a per-[environment](#environment) basis.
 
 While defining, you can assign a custom priority to each location. This priority determines which location will be filled first.
 
+## Region Type
+
+A Region Type defines a class of infrastructure (for example, bare-metal or cloud) within a [Region](#region).
+Each Region Type has its own scaling parameters, and an [Armada](#armada) can have multiple Region Types per Region to balance cost and availability.
+
 ## Replica
 
 A Replica is an individual game server instance within an [Armada](#armada).

--- a/src/multiplayer-servers/multiplayer-services/scaling.md
+++ b/src/multiplayer-servers/multiplayer-services/scaling.md
@@ -7,9 +7,9 @@ Each mechanism addresses a different aspect of scaling, from static configuratio
 
 Every Armada is configured with three core scaling parameters per Region Type:
 
-- **Minimum Replicas** -- the lowest number of game servers running at any time.
-- **Maximum Replicas** -- the upper bound on game servers that can be started.
-- **Buffer Size** -- the approximate number of game servers kept in the `Ready` state, waiting to be allocated.
+- **Minimum Replicas**: the lowest number of game servers running at any time.
+- **Maximum Replicas**: the upper bound on game servers that can be started.
+- **Buffer Size**: the approximate number of game servers kept in the `Ready` state, waiting to be allocated.
 
 These values determine how quickly players find a game server and how much idle capacity is maintained.
 Getting them right depends on game server startup time, session duration, and expected concurrent users.

--- a/src/multiplayer-servers/multiplayer-services/scaling.md
+++ b/src/multiplayer-servers/multiplayer-services/scaling.md
@@ -1,0 +1,40 @@
+# Armada scaling
+
+GameFabric provides several mechanisms to control game server capacity per Region Type, balancing cost and player availability.
+Each mechanism addresses a different aspect of scaling, from static configuration to demand-driven automation.
+
+## Replicas and buffer size
+
+Every Armada is configured with three core scaling parameters per Region Type:
+
+- **Minimum Replicas** -- the lowest number of game servers running at any time.
+- **Maximum Replicas** -- the upper bound on game servers that can be started.
+- **Buffer Size** -- the approximate number of game servers kept in the `Ready` state, waiting to be allocated.
+
+These values determine how quickly players find a game server and how much idle capacity is maintained.
+Getting them right depends on game server startup time, session duration, and expected concurrent users.
+
+For detailed guidance, including worked examples and input validation rules, see [Replicas and buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer).
+
+## Dynamic buffer (Alpha)
+
+Instead of choosing a fixed buffer size, the Dynamic Buffer option lets GameFabric adjust the buffer automatically based on observed player demand.
+
+When enabled, GameFabric recalculates the buffer at two levels: a baseline per Region Type derived from overall demand trends, and a per-Site local adjustment based on `Ready` and `Allocated` counts, startup time, and allocation patterns.
+A slider controls the trade-off between cost efficiency and availability.
+
+Dynamic Buffer requires at least 24 hours of allocation data to stabilize and should be monitored closely after enabling.
+
+For configuration details and slider values, see [Dynamically configuring the buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer#dynamically-configuring-the-buffer-size-alpha).
+
+## Scale to Zero (Alpha)
+
+Scale to Zero is a cost-saving feature that scales down lower-priority Region Types when there is no demand, and automatically scales them back up when demand returns.
+
+It works by monitoring utilization across Region Types within a Region.
+When the higher-priority Region Type (for example, baremetal) has spare capacity, GameFabric can scale the lower-priority Region Type (for example, cloud) down to zero replicas.
+When utilization rises above a configurable threshold, the lower-priority Region Type is scaled back up.
+
+Scale to Zero requires at least two Region Types per Region and is configurable per Armada and Region.
+
+For a full explanation of utilization metrics, panic behavior, and configuration options, see [Scale to Zero](/multiplayer-servers/multiplayer-services/scale-to-zero).

--- a/src/multiplayer-servers/multiplayer-services/scaling.md
+++ b/src/multiplayer-servers/multiplayer-services/scaling.md
@@ -1,7 +1,7 @@
 # Armada scaling
 
-GameFabric provides several mechanisms to control game server capacity per Region Type, balancing cost and player availability.
-Each mechanism addresses a different aspect of scaling, from static configuration to demand-driven automation.
+GameFabric provides several ways to control game server capacity per [Region Type](/multiplayer-servers/getting-started/glossary#region-type), balancing cost and player availability.
+Each addresses a different aspect of scaling, from static configuration to demand-driven automation.
 
 ## Replicas and buffer size
 
@@ -14,16 +14,16 @@ Every Armada is configured with three core scaling parameters per Region Type:
 These values determine how quickly players find a game server and how much idle capacity is maintained.
 Getting them right depends on game server startup time, session duration, and expected concurrent users.
 
-For detailed guidance, including worked examples and input validation rules, see [Replicas and buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer).
+For detailed guidance, including examples and input validation rules, see [Replicas and buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer).
 
-## Dynamic buffer (Alpha)
+## Dynamic Buffer (Alpha)
 
 Instead of choosing a fixed buffer size, the Dynamic Buffer option lets GameFabric adjust the buffer automatically based on observed player demand.
 
 When enabled, GameFabric recalculates the buffer at two levels: a baseline per Region Type derived from overall demand trends, and a per-Site local adjustment based on `Ready` and `Allocated` counts, startup time, and allocation patterns.
 A slider controls the trade-off between cost efficiency and availability.
 
-Dynamic Buffer requires at least 24 hours of allocation data. After you enable it, it can take up to 48 hours to stabilize, so monitor it closely during that period.
+Dynamic Buffer requires at least 24 hours of allocation data. Once enabled, it takes up to 48 hours to stabilize, so monitor it closely during that period.
 
 For configuration details and slider values, see [Dynamically configuring the buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer#dynamically-configuring-the-buffer-size-alpha).
 

--- a/src/multiplayer-servers/multiplayer-services/scaling.md
+++ b/src/multiplayer-servers/multiplayer-services/scaling.md
@@ -23,7 +23,7 @@ Instead of choosing a fixed buffer size, the Dynamic Buffer option lets GameFabr
 When enabled, GameFabric recalculates the buffer at two levels: a baseline per Region Type derived from overall demand trends, and a per-Site local adjustment based on `Ready` and `Allocated` counts, startup time, and allocation patterns.
 A slider controls the trade-off between cost efficiency and availability.
 
-Dynamic Buffer requires at least 24 hours of allocation data to stabilize and should be monitored closely after enabling.
+Dynamic Buffer requires at least 24 hours of allocation data. After you enable it, it can take up to 48 hours to stabilize, so monitor it closely during that period.
 
 For configuration details and slider values, see [Dynamically configuring the buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer#dynamically-configuring-the-buffer-size-alpha).
 

--- a/src/multiplayer-servers/multiplayer-services/sidebar.json
+++ b/src/multiplayer-servers/multiplayer-services/sidebar.json
@@ -49,6 +49,10 @@
       "text": "Armada Scaling",
       "items": [
         {
+          "text": "Scaling Overview",
+          "link": "/multiplayer-services/scaling"
+        },
+        {
           "text": "Replicas and Buffer Size",
           "link": "/multiplayer-services/armada-replicas-and-buffer"
         },


### PR DESCRIPTION
## Summary

- Adds a new "Scaling Overview" page at `/multiplayer-services/scaling`
  that briefly describes each Armada scaling mechanism and links to the
  detailed documentation.
- Adds the overview as the first item in the "Armada Scaling" sidebar
  group introduced by #265.

## Motivation

The GameFabric UI needs a stable URL to link users to scaling
documentation. Rather than linking to one of the three individual pages,
this overview serves as a single entry point that covers:

1. **Replicas and buffer size** -- static min/max replicas and buffer
   configuration.
2. **Dynamic buffer (Alpha)** -- demand-driven automatic buffer
   adjustment.
3. **Scale to Zero (Alpha)** -- automatic scale-down of lower-priority
   Region Types when demand is low.

## Changes

| File | Change |
|------|--------|
| `src/multiplayer-servers/multiplayer-services/scaling.md` | New overview page |
| `src/multiplayer-servers/multiplayer-services/sidebar.json` | Added "Scaling Overview" entry to the "Armada Scaling" group |

## How did I verify the changes?

- `docker run --rm gamefabric-docs-dev yarn docs:build` passes with no
  dead links or errors.