### PR TITLE
docs: document Help Center RBAC access requirements

### DIFF
--- a/src/multiplayer-servers/authentication/editing-permissions.md
+++ b/src/multiplayer-servers/authentication/editing-permissions.md
@@ -81,7 +81,11 @@ To bulk edit these permissions, use the checkboxes beside the resource name.
 
 Access to the [GameFabric Help Center](/multiplayer-servers/getting-started/glossary#gamefabric-help-center) is controlled through RBAC. Users must have the `HELPCENTER` permission to access the Help Center link in the GameFabric UI.
 
-By default, this permission is included in the `default:help-center` role, and the `default:help-center` group is bound to that role. To grant Help Center access, either add users to this default group or assign the `HELPCENTER` permission to a custom role.
+By default, this permission is included in the `default:help-center` role, and the `default:help-center` group is bound to that role. A user has access to the Help Center if one of the following is true:
+
+- Is a member of the `default:help-center` group.
+- Is in a group that is bound to the `default:help-center` role.
+- Is in a group bound to any role that includes the `HELPCENTER` permission.
 
 ## Service Account
 

--- a/src/multiplayer-servers/authentication/editing-permissions.md
+++ b/src/multiplayer-servers/authentication/editing-permissions.md
@@ -77,6 +77,12 @@ To edit environment-based permissions, expand the resource by clicking the arrow
 To bulk edit these permissions, use the checkboxes beside the resource name.
 ![edit-role-env-based.png](images/permissions/edit-role-env-based.png)
 
+## Help Center
+
+Access to the [GameFabric Help Center](/multiplayer-servers/getting-started/glossary#gamefabric-help-center) is controlled through RBAC. Users must have the `HELPCENTER` permission to access the Help Center link in the GameFabric UI.
+
+By default, this permission is included in the `default:help-center` role, which is bound to the `default:help-center` group. To grant Help Center access, either add users to this default group or assign the `HELPCENTER` permission to a custom role.
+
 ## Service Account
 
 For the management of Service Accounts, refer to the [Service Accounts](/multiplayer-servers/authentication/service-accounts) section.

--- a/src/multiplayer-servers/authentication/editing-permissions.md
+++ b/src/multiplayer-servers/authentication/editing-permissions.md
@@ -81,7 +81,7 @@ To bulk edit these permissions, use the checkboxes beside the resource name.
 
 Access to the [GameFabric Help Center](/multiplayer-servers/getting-started/glossary#gamefabric-help-center) is controlled through RBAC. Users must have the `HELPCENTER` permission to access the Help Center link in the GameFabric UI.
 
-By default, this permission is included in the `default:help-center` role, which is bound to the `default:help-center` group. To grant Help Center access, either add users to this default group or assign the `HELPCENTER` permission to a custom role.
+By default, this permission is included in the `default:help-center` role, and the `default:help-center` group is bound to that role. To grant Help Center access, either add users to this default group or assign the `HELPCENTER` permission to a custom role.
 
 ## Service Account
 

--- a/src/multiplayer-servers/authentication/editing-permissions.md
+++ b/src/multiplayer-servers/authentication/editing-permissions.md
@@ -79,13 +79,13 @@ To bulk edit these permissions, use the checkboxes beside the resource name.
 
 ## Help Center
 
-Access to the [GameFabric Help Center](/multiplayer-servers/getting-started/glossary#gamefabric-help-center) is controlled through RBAC. Users must have the `HELPCENTER` permission to access the Help Center link in the GameFabric UI.
+Access to the [GameFabric Help Center](/multiplayer-servers/getting-started/glossary#gamefabric-help-center) is controlled through RBAC. Users must have the `helpcenter` permission to access the Help Center link in the GameFabric UI.
 
 By default, this permission is included in the `default:help-center` role, and the `default:help-center` group is bound to that role. A user has access to the Help Center if one of the following is true:
 
 - Is a member of the `default:help-center` group.
 - Is in a group that is bound to the `default:help-center` role.
-- Is in a group bound to any role that includes the `HELPCENTER` permission.
+- Is in a group bound to any role that includes the `helpcenter` permission.
 
 ## Service Account
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -128,17 +128,7 @@ The GameFabric Help Center is the central place for all self-service feature req
 
 ![Help Center menu location](images/glossary/help-center-menu.png)
 
-### Access control
-
-Access to the Help Center requires the `HELPCENTER` permission. By default, GameFabric bootstraps a `default:help-center` group bound to the `default:help-center` role, which includes this permission.
-
-A user can access the Help Center in any of the following ways:
-
-- Is a member of the `default:help-center` group.
-- Is in a group that is bound to the `default:help-center` role.
-- Is in a group bound to any role that includes the `HELPCENTER` permission.
-
-For details on managing groups and roles, see [Editing Permissions](/multiplayer-servers/authentication/editing-permissions).
+For access control details, see [Editing Permissions](/multiplayer-servers/authentication/editing-permissions#help-center).
 
 ## Gateway Policies
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -134,9 +134,9 @@ Access to the Help Center requires the `HELPCENTER` permission. By default, Game
 
 A user can access the Help Center in any of the following ways:
 
-- Be a member of the `default:help-center` group.
-- Be in a group that is bound to the `default:help-center` role.
-- Be in a group bound to any role that includes the `HELPCENTER` permission.
+- Is a member of the `default:help-center` group.
+- Is in a group that is bound to the `default:help-center` role.
+- Is in a group bound to any role that includes the `HELPCENTER` permission.
 
 For details on managing groups and roles, see [Editing Permissions](/multiplayer-servers/authentication/editing-permissions).
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -128,6 +128,18 @@ The GameFabric Help Center is the central place for all self-service feature req
 
 ![Help Center menu location](images/glossary/help-center-menu.png)
 
+### Access control
+
+Access to the Help Center requires the `HELPCENTER` permission. By default, GameFabric bootstraps a `default:help-center` group bound to the `default:help-center` role, which includes this permission.
+
+A user can access the Help Center in any of the following ways:
+
+- Be a member of the `default:help-center` group.
+- Be in a group that is bound to the `default:help-center` role.
+- Be in a group bound to any role that includes the `HELPCENTER` permission.
+
+For details on managing groups and roles, see [Editing Permissions](/multiplayer-servers/authentication/editing-permissions).
+
 ## Gateway Policies
 
 See also [SteelShield docs](/steelshield/gamefabric/gamefabric#gateway-policies).


### PR DESCRIPTION
## Summary

- Add RBAC access control details to the Help Center glossary entry, documenting
  the `HELPCENTER` permission and the three ways users can gain access
  (default group, default role binding, or custom role).
- Add a Help Center section to the Editing Permissions page for discoverability
  when users troubleshoot access issues.