### PR TITLE
docs: add missing ALLOC_REGION env var to allocation sidecar configuration

### DIFF
--- a/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
+++ b/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
@@ -78,9 +78,9 @@ It requires you to select the image, which is provided under the `system` branch
 and a `Passthrough` port, using `TCP` protocol, named `allocator`.
 This is so that the allocation service can reach the Allocation Sidecar.
 
-Now specify the URL, region, and authentication token for the allocation service
-using the `ALLOC_URL`, `ALLOC_REGION`, and `ALLOC_TOKEN` environment variables.
-It is recommended to set it in the Region, so any Formation, Vessel, ArmadaSet or Armada
+Now specify the required `ALLOC_URL`, `ALLOC_REGION`, and `ALLOC_TOKEN` environment variables
+for the allocation service. Without these three variables, the Allocation Sidecar will not function.
+It is recommended to set these environment variables on the Region, so any Formation, Vessel, ArmadaSet or Armada
 within that region is automatically configured.
 
 ::: warning
@@ -203,6 +203,10 @@ All environment variables described in this guide must be added to the Allocatio
 not to your game server container.
 Any parent resource, such as Region or Site can also provide these environment variables
 
+## Required configuration
+
+The following environment variables are required for the Allocation Sidecar to function.
+
 ### `ALLOC_URL` (`string`)
 
 The allocation service endpoint URL.
@@ -214,6 +218,10 @@ The authentication bearer for the allocation service endpoint.
 ### `ALLOC_REGION` (`string`)
 
 The region identifier used for the game server registration.
+
+## Optional configuration
+
+The following environment variables are optional and enable additional functionality.
 
 ### `ALLOC_PRIORITY` (`int=0`)
 

--- a/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
+++ b/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
@@ -209,7 +209,15 @@ The following environment variables are required for the Allocation Sidecar to f
 
 ### `ALLOC_URL` (`string`)
 
-The allocation service endpoint URL.
+The allocation service endpoint URL. The URL must end with `/servers`.
+
+Example:
+
+```text
+https://<your-installation>.gamefabric.dev/allocator/prod/us/servers
+```
+
+See [API Specs - Allocation: Registry](/api/multiplayer-servers/allocation-registry#tag/Registry) for details.
 
 ### `ALLOC_TOKEN` (`string`)
 

--- a/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
+++ b/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
@@ -78,8 +78,8 @@ It requires you to select the image, which is provided under the `system` branch
 and a `Passthrough` port, using `TCP` protocol, named `allocator`.
 This is so that the allocation service can reach the Allocation Sidecar.
 
-Now specify the URL and authentication token for the allocation service
-using the `ALLOC_URL` and `ALLOC_TOKEN` environment variables.
+Now specify the URL, region, and authentication token for the allocation service
+using the `ALLOC_URL`, `ALLOC_REGION`, and `ALLOC_TOKEN` environment variables.
 It is recommended to set it in the Region, so any Formation, Vessel, ArmadaSet or Armada
 within that region is automatically configured.
 
@@ -210,6 +210,10 @@ The allocation service endpoint URL.
 ### `ALLOC_TOKEN` (`string`)
 
 The authentication bearer for the allocation service endpoint.
+
+### `ALLOC_REGION` (`string`)
+
+The region identifier used for the game server registration.
 
 ### `ALLOC_PRIORITY` (`int=0`)
 

--- a/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
+++ b/src/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers.md
@@ -197,13 +197,11 @@ a partial payload may be sent.
 Static payload variables can also be sent by [adding the environment variable `ALLOC_CALLBACK_PAYLOAD_VARS`](#alloc_callback_payload_vars-string) on
 the Allocation Sidecar container.
 
-## Advanced configuration
+## Required configuration
 
 All environment variables described in this guide must be added to the Allocation Sidecar container,
 not to your game server container.
-Any parent resource, such as Region or Site can also provide these environment variables
-
-## Required configuration
+Any parent resource, such as Region or Site can also provide these environment variables.
 
 The following environment variables are required for the Allocation Sidecar to function.
 


### PR DESCRIPTION
## Summary

- Add `ALLOC_REGION` environment variable to the Allocation Sidecar's Advanced Configuration section, placed alongside `ALLOC_URL` and `ALLOC_TOKEN` as a core registration parameter.
- Update the Configuration section to mention `ALLOC_REGION` as a required env var when setting up the sidecar.