### PR TITLE
docs: clarify buffer impact on scale-to-zero utilization thresholds

### DIFF
--- a/src/multiplayer-servers/multiplayer-services/scale-to-zero.md
+++ b/src/multiplayer-servers/multiplayer-services/scale-to-zero.md
@@ -127,12 +127,12 @@ The **max replicas** are the maximum number of replicas.
 It is configurable as part of the Distribution, see **GameFabric > Armada > Scaling** or via API `armada.spec.distribution[].maxReplicas`.
 
 ::: tip Buffer impact on utilization
-Since replicas include servers in all states, a large buffer of Ready servers contributes to the utilization calculation.
-For example, with `maxReplicas: 1000`, 600 Allocated servers and a buffer of 200 Ready servers results in 80% replica utilization — potentially triggering cloud scale-up even though only 60% of capacity is serving players.
+Since replicas include servers in all states, a large buffer of `Ready` servers contributes to the utilization calculation.
+For example, with `maxReplicas: 1000`, a configuration with 600 `Allocated` servers and a buffer of 200 `Ready` servers results in 80% replica utilization — potentially triggering the cloud to scale up even though only 60% of capacity is serving players.
 
-When configuring Scale Up Utilization, account for your buffer size. A larger buffer requires a higher scale-up threshold to avoid premature cloud activation.
+When configuring Scale Up Utilization, account for your buffer size. A larger buffer requires a higher scale up threshold to avoid premature cloud activation.
 
-When using [Dynamic Buffers](./armada-replicas-and-buffer#dynamically-configuring-the-buffer-size), the buffer size fluctuates based on demand, making baseline utilization less predictable. Availability-focused settings produce larger buffers and increase the likelihood of earlier cloud scale-up. Consider this when choosing your Scale Up Utilization threshold.
+When using [Dynamic Buffers](./armada-replicas-and-buffer#dynamically-configuring-the-buffer-size), the buffer size fluctuates based on demand, making baseline utilization less predictable. Availability-focused settings produce larger buffers and increase the likelihood of earlier cloud scale up. Consider this when choosing your Scale Up Utilization threshold.
 :::
 
 ### Resource usage
@@ -219,10 +219,10 @@ It is recommended to have at least a 5% gap between the two.
 
 ### Choosing thresholds with a large buffer
 
-When using baremetal with a sizeable Ready buffer, consider that your baseline utilization already includes those buffer servers.
+When using baremetal with a sizable `Ready` buffer, consider that your baseline utilization already includes those buffer servers.
 Your effective "idle" replica utilization is approximately `(allocated + buffer) / maxReplicas`.
 Set your Scale Up Utilization above this baseline to avoid unnecessary cloud scale-up.
-Alternatively, reduce your buffer size if cloud scale-up is triggering too early.
+Alternatively, reduce your buffer size if cloud scale up is triggering too early.
 
 When [Dynamic Buffers](./armada-replicas-and-buffer#dynamically-configuring-the-buffer-size) are enabled, the buffer size changes automatically. With availability-focused settings, allow additional headroom in your Scale Up Utilization threshold to account for buffer increases during demand peaks.
 

--- a/src/multiplayer-servers/multiplayer-services/scale-to-zero.md
+++ b/src/multiplayer-servers/multiplayer-services/scale-to-zero.md
@@ -130,7 +130,7 @@ It is configurable as part of the Distribution, see **GameFabric > Armada > Scal
 Since replicas include servers in all states, a large buffer of `Ready` servers contributes to the utilization calculation.
 For example, with `maxReplicas: 1000`, a configuration with 600 `Allocated` servers and a buffer of 200 `Ready` servers results in 80% replica utilization — potentially triggering the cloud to scale up even though only 60% of capacity is serving players.
 
-When configuring Scale Up Utilization, account for your buffer size. A larger buffer requires a higher scale up threshold to avoid premature cloud activation.
+When configuring Scale Up Utilization, account for your Buffer Size. A larger buffer requires a higher scale up threshold to avoid premature cloud activation.
 
 When using [Dynamic Buffers](./armada-replicas-and-buffer#dynamically-configuring-the-buffer-size), the buffer size fluctuates based on demand, making baseline utilization less predictable. Availability-focused settings produce larger buffers and increase the likelihood of earlier cloud scale up. Consider this when choosing your Scale Up Utilization threshold.
 :::
@@ -221,8 +221,8 @@ It is recommended to have at least a 5% gap between the two.
 
 When using baremetal with a sizable `Ready` buffer, consider that your baseline utilization already includes those buffer servers.
 Your effective "idle" replica utilization is approximately `(allocated + buffer) / maxReplicas`.
-Set your Scale Up Utilization above this baseline to avoid unnecessary cloud scale-up.
-Alternatively, reduce your buffer size if cloud scale up is triggering too early.
+Set your Scale Up Utilization above this baseline to avoid unnecessary cloud scale up.
+Alternatively, reduce your Buffer Size if cloud scale up is triggering too early.
 
 When [Dynamic Buffers](./armada-replicas-and-buffer#dynamically-configuring-the-buffer-size) are enabled, the buffer size changes automatically. With availability-focused settings, allow additional headroom in your Scale Up Utilization threshold to account for buffer increases during demand peaks.
 

--- a/src/multiplayer-servers/multiplayer-services/scale-to-zero.md
+++ b/src/multiplayer-servers/multiplayer-services/scale-to-zero.md
@@ -126,6 +126,15 @@ This number includes all game servers in all states, including but not limited t
 The **max replicas** are the maximum number of replicas.
 It is configurable as part of the Distribution, see **GameFabric > Armada > Scaling** or via API `armada.spec.distribution[].maxReplicas`.
 
+::: tip Buffer impact on utilization
+Since replicas include servers in all states, a large buffer of Ready servers contributes to the utilization calculation.
+For example, with `maxReplicas: 1000`, 600 Allocated servers and a buffer of 200 Ready servers results in 80% replica utilization — potentially triggering cloud scale-up even though only 60% of capacity is serving players.
+
+When configuring Scale Up Utilization, account for your buffer size. A larger buffer requires a higher scale-up threshold to avoid premature cloud activation.
+
+When using [Dynamic Buffers](./armada-replicas-and-buffer#dynamically-configuring-the-buffer-size), the buffer size fluctuates based on demand, making baseline utilization less predictable. Availability-focused settings produce larger buffers and increase the likelihood of earlier cloud scale-up. Consider this when choosing your Scale Up Utilization threshold.
+:::
+
 ### Resource usage
 
 Another metric to calculate the utilization is the resource usage divided by the resource limits. Numbers are collected per Region Type.
@@ -207,6 +216,15 @@ Finding a good configuration is crucial for a good balance between cost-saving a
 
 It is allowed to set both Scale Up and Scale Down Utilization to the same value, but this can lead to flapping and increased scaling activity.
 It is recommended to have at least a 5% gap between the two.
+
+### Choosing thresholds with a large buffer
+
+When using baremetal with a sizeable Ready buffer, consider that your baseline utilization already includes those buffer servers.
+Your effective "idle" replica utilization is approximately `(allocated + buffer) / maxReplicas`.
+Set your Scale Up Utilization above this baseline to avoid unnecessary cloud scale-up.
+Alternatively, reduce your buffer size if cloud scale-up is triggering too early.
+
+When [Dynamic Buffers](./armada-replicas-and-buffer#dynamically-configuring-the-buffer-size) are enabled, the buffer size changes automatically. With availability-focused settings, allow additional headroom in your Scale Up Utilization threshold to account for buffer increases during demand peaks.
 
 ::: info
 The UI only allows to set the Scale Up Utilization, and automatically sets the Scale Down Utilization to 5% less.


### PR DESCRIPTION
## Summary

- Add a tip box explaining that Ready (buffer) servers contribute to replica utilization and can cause premature cloud scale-up
- Add a "Choosing thresholds with a large buffer" subsection with practical guidance on setting Scale Up Utilization
- Reference Dynamic Buffers interaction in both additions, noting that availability-focused settings amplify the effect

## Context

Based on customer feedback where the relationship between buffer size and Scale to Zero utilization thresholds was not immediately clear from the existing documentation. A user with a large baremetal buffer was surprised that Ready servers count toward the utilization that triggers cloud scale-up.