### PR TITLE
feat(STS-2542): Add UE 5.7.4 to the support engine version list

### DIFF
--- a/src/steelshield/unreal-engine-plugin/requirements.md
+++ b/src/steelshield/unreal-engine-plugin/requirements.md
@@ -13,6 +13,7 @@ The following versions of Unreal Engine are officially supported for the SteelSh
 - UE 5.2.1
 - UE 5.5.3
 - UE 5.6.1
+- UE 5.7.4
 
 If the version of the engine you use is not listed above, you can often use the closest matching patch version for your major and minor engine version (for example, 5.2.x for 5.2.3).
 Before using an unlisted version in production, run extensive end-to-end tests in GameFabric with Proof of Identity enabled and confirm that SteelShield handles all network traffic correctly.


### PR DESCRIPTION
## Goal of this PR

Update the Unreal Engine Plugin section to include UE 5.7.4 as a supported version

## How did I verify the changes?

Ocular Interrogation

## Additional context

N/A