### PR TITLE
docs: add debugging guide, Degraded glossary entry, and update Dockerfile examples

### DIFF
--- a/src/multiplayer-servers/getting-started/building-a-container-image.md
+++ b/src/multiplayer-servers/getting-started/building-a-container-image.md
@@ -68,7 +68,7 @@ Here is an example, where this Dockerfile builds an image that runs the game ser
 
 ```Dockerfile
 # 1. Select an operating system.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # 2. Pre-install requirements.
 RUN apt-get update \
@@ -76,13 +76,11 @@ RUN apt-get update \
         && apt-get clean -y
 
 # 3. Prepare a working directory and permissions.
-RUN mkdir /app
-RUN useradd -m -u 1000 gameserver
-RUN chown gameserver:gameserver /app
+RUN mkdir /app && chown 1000:1000 /app
 
 # 4. Prepare your game server binary.
 USER 1000
-COPY --chown=gameserver:gameserver path/to/gameserver /app/
+COPY --chown=1000:1000 path/to/gameserver /app/
 RUN chmod +x /app/gameserver
 WORKDIR /app
 
@@ -90,13 +88,13 @@ CMD ["/app/gameserver"]
 ```
 
 1. First, select a Linux operating system, ideally a minimal one to reduce the overall image size, but
-   for the sake of simplicity this example uses Ubuntu 22.04 (LTS).
+   for the sake of simplicity this example uses Ubuntu 24.04 (LTS).
 
 2. Update the dependencies to ensure all security patches are included in the built image.
    Additionally, install anything that is required to run the game server binary.
    Keep in mind that this is a blank system, without pre-installed custom libraries.
 
-3. Create a user with uid 1000 and set up a working directory owned by that user.
+3. Set up a working directory owned by uid 1000.
    GameFabric runs the container process as uid 1000 via the pod security context,
    so file ownership must match to avoid permission errors at runtime.
 

--- a/src/multiplayer-servers/getting-started/building-a-container-image.md
+++ b/src/multiplayer-servers/getting-started/building-a-container-image.md
@@ -61,7 +61,7 @@ For example, this typically includes fetching dependencies required to run the b
 on certain folders or just copying and moving files.
 
 ::: warning Container user
-GameFabric enforces uid 1000 via the Kubernetes pod security context (`runAsUser: 1000`). The container process always runs as uid 1000, regardless of the `USER` instruction in the Dockerfile. Your Dockerfile should create a user with uid 1000 and ensure all files the game server needs are owned by or readable by that user. See [Quotas](/multiplayer-servers/multiplayer-services/quotas#user-id) for more details.
+GameFabric enforces uid 1000 via the Kubernetes pod security context (`runAsUser: 1000`). The container process always runs as uid 1000, regardless of the `USER` instruction in the Dockerfile. Ensure all files the game server needs are owned by or readable by uid 1000. See [Quotas](/multiplayer-servers/multiplayer-services/quotas#user-id) for more details.
 :::
 
 Here is an example, where this Dockerfile builds an image that runs the game server:

--- a/src/multiplayer-servers/getting-started/building-a-container-image.md
+++ b/src/multiplayer-servers/getting-started/building-a-container-image.md
@@ -73,7 +73,8 @@ FROM ubuntu:24.04
 # 2. Pre-install requirements.
 RUN apt-get update \
         && apt-get install -y gnupg ca-certificates \
-        && apt-get clean -y
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
 
 # 3. Prepare a working directory and permissions.
 RUN mkdir /app && chown 1000:1000 /app

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -87,6 +87,14 @@ For more information, see the [Kubernetes documentation](https://kubernetes.io/d
 
 When a [Site](#site) is marked as cordoned, it becomes unschedulable. Allocated game servers continue to run until they shut down, but no new game servers get scheduled on that Site.
 
+## Degraded
+
+A synchronization state indicating that configuration could not be deployed to one or more [Sites](#site). This can occur when Sites are unavailable, experiencing connectivity issues, or when all capacity in a Location has been deprovisioned.
+
+Objects that can be Degraded: [Armada](#armada), [ArmadaSet](#armadaset), [Formation](#formation), Secret, ConfigFile, Protocol, Gateway Policy.
+
+The reason for the Degraded state is shown in the UI next to the affected object and is also available via the API in the `status.reason` field.
+
 ## Dynamic Buffer
 
 Dynamic Buffer is a feature that automatically adjusts the [Buffer](#buffer) based on current game server demand. When enabled, GameFabric monitors the number of `Ready` and `Allocated` game servers, startup time, and demand on each [Site](#site), then scales the buffer accordingly.

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -286,12 +286,6 @@ This can be the case, for example, when a Site has just been provisioned to prev
 
 An account used for accessing GameFabric programmatically. For details, see the documentation in [Service Accounts](/multiplayer-servers/authentication/service-accounts#managing-service-accounts).
 
-## SteelShield™
-
-SteelShield is a DDoS protection system designed for the specific purpose of protecting game servers from large scale DDoS attacks.
-
-See also [SteelShield docs](/steelshield/gamefabric/introduction).
-
 ## State
 
 Every GameFabric resource exposes a `status.state` field that reflects its current condition. States are specific to each resource type:
@@ -301,6 +295,12 @@ Every GameFabric resource exposes a `status.state` field that reflects its curre
 - **Formations:** `Synced`, [Degraded](#degraded).
 
 When a resource is not in its expected state, the `status.reason` field may provide additional context where available, visible in the UI and via the API.
+
+## SteelShield™
+
+SteelShield is a DDoS protection system designed for the specific purpose of protecting game servers from large scale DDoS attacks.
+
+See also [SteelShield docs](/steelshield/gamefabric/introduction).
 
 ## Terraform provider
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -91,9 +91,9 @@ When a [Site](#site) is marked as cordoned, it becomes unschedulable. Allocated 
 
 A synchronization state indicating that configuration could not be deployed to one or more [Sites](#site). This can occur when Sites are unavailable, experiencing connectivity issues, or when all capacity in a Location has been deprovisioned.
 
-Objects that can be Degraded: [Armada](#armada), [ArmadaSet](#armadaset), [Formation](#formation), [Secret](#secret), ConfigFile, Protocol, [Gateway Policies](#gateway-policies).
+Objects that can be Degraded: [Armada](#armada), [ArmadaSet](#armadaset), [Formation](#formation), [Secret](#secret), ConfigFile, Protocol.
 
-The reason for the Degraded state is shown in the UI next to the affected object and is also available via the API in the `status.reason` field.
+For Armadas, ArmadaSets, Formations, and Protocols, the `status.reason` field provides additional context and is visible in the UI next to the affected object.
 
 ## Dynamic Buffer
 
@@ -291,6 +291,16 @@ An account used for accessing GameFabric programmatically. For details, see the 
 SteelShield is a DDoS protection system designed for the specific purpose of protecting game servers from large scale DDoS attacks.
 
 See also [SteelShield docs](/steelshield/gamefabric/introduction).
+
+## State
+
+Every GameFabric resource exposes a `status.state` field that reflects its current condition. States are specific to each resource type:
+
+- **Vessels:** `Pending`, `Scheduled`, `Created`, `Starting`, `Running`, `Terminating`, `Error`, `Suspended`. See [Vessel states](/multiplayer-servers/getting-started/vessel-states).
+- **Armadas and ArmadaSets:** `Synced`, [Degraded](#degraded).
+- **Formations:** `Synced`, [Degraded](#degraded).
+
+When a resource is not in its expected state, the `status.reason` field may provide additional context where available, visible in the UI and via the API.
 
 ## Terraform provider
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -91,7 +91,7 @@ When a [Site](#site) is marked as cordoned, it becomes unschedulable. Allocated 
 
 A synchronization state indicating that configuration could not be deployed to one or more [Sites](#site). This can occur when Sites are unavailable, experiencing connectivity issues, or when all capacity in a Location has been deprovisioned.
 
-Objects that can be Degraded: [Armada](#armada), [ArmadaSet](#armadaset), [Formation](#formation), Secret, ConfigFile, Protocol, Gateway Policy.
+Objects that can be Degraded: [Armada](#armada), [ArmadaSet](#armadaset), [Formation](#formation), [Secret](#secret), ConfigFile, Protocol, [Gateway Policies](#gateway-policies).
 
 The reason for the Degraded state is shown in the UI next to the affected object and is also available via the API in the `status.reason` field.
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -91,9 +91,9 @@ When a [Site](#site) is marked as cordoned, it becomes unschedulable. Allocated 
 
 A synchronization state indicating that configuration could not be deployed to one or more [Sites](#site). This can occur when Sites are unavailable, experiencing connectivity issues, or when all capacity in a Location has been deprovisioned.
 
-Objects that can be Degraded: [Armada](#armada), [ArmadaSet](#armadaset), [Formation](#formation), [Secret](#secret), ConfigFile, Protocol.
+Objects that can be Degraded: [Armada](#armada), [ArmadaSet](#armadaset), [Formation](#formation), [Secret](#secret), ConfigFile, [Protection Protocol](#protection-protocol).
 
-For Armadas, ArmadaSets, Formations, and Protocols, the `status.reason` field provides additional context and is visible in the UI next to the affected object.
+For Armadas, ArmadaSets, Formations, and Protection Protocols, the `status.reason` field provides additional context and is visible in the UI next to the affected object.
 
 ## Dynamic Buffer
 

--- a/src/multiplayer-servers/getting-started/quickstart.md
+++ b/src/multiplayer-servers/getting-started/quickstart.md
@@ -29,12 +29,10 @@ Create a Branch in the GameFabric UI under **Container Images > Branches**.
 Package your game server into a Docker container. A minimal Dockerfile might look like:
 
 ```Dockerfile
-FROM ubuntu:22.04
-
-# Create a non-root user with uid 1000 (enforced by GameFabric's pod security context)
-RUN groupadd -g 1000 game && useradd -u 1000 -g 1000 -m game
+FROM ubuntu:24.04
 
 COPY gameserver /app/gameserver
+# GameFabric runs containers as uid 1000 (enforced by the pod security context)
 RUN chown 1000:1000 /app/gameserver
 
 USER 1000

--- a/src/multiplayer-servers/monitoring/debugging.md
+++ b/src/multiplayer-servers/monitoring/debugging.md
@@ -100,7 +100,8 @@ FROM ubuntu:24.04
 # 2. Pre-install requirements.
 RUN apt-get update \
         && apt-get install -y gnupg ca-certificates curl jq \
-        && apt-get clean -y
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*
 
 # 3. Prepare a working directory and permissions.
 RUN mkdir /app && chown 1000:1000 /app

--- a/src/multiplayer-servers/monitoring/debugging.md
+++ b/src/multiplayer-servers/monitoring/debugging.md
@@ -125,8 +125,9 @@ For more details on building container images, see [Building a container image](
 
 ### Adding the debug sidecar to your game server
 
-1. Navigate to your [Formation](/multiplayer-servers/getting-started/glossary#formation), [Vessel](/multiplayer-servers/getting-started/glossary#vessel), [ArmadaSet](/multiplayer-servers/getting-started/glossary#armadaset), or [Armada](/multiplayer-servers/getting-started/glossary#armada) configuration.
-1. In the **Sidecars** section, select **Create from scratch**.
+1. Navigate to your [Formation](/multiplayer-servers/getting-started/glossary#formation), [Vessel](/multiplayer-servers/getting-started/glossary#vessel), [ArmadaSet](/multiplayer-servers/getting-started/glossary#armadaset), or [Armada](/multiplayer-servers/getting-started/glossary#armada) detail view.
+1. Go to **Settings → Containers** and select **Add Sidecar Container**.
+1. Select **Create from scratch**.
 1. Set the container image to your debug sidecar image.
 1. Save your changes.
 

--- a/src/multiplayer-servers/monitoring/debugging.md
+++ b/src/multiplayer-servers/monitoring/debugging.md
@@ -93,7 +93,7 @@ done
 
 The Dockerfile:
 
-```dockerfile
+```Dockerfile
 # 1. Select an operating system.
 FROM ubuntu:24.04
 

--- a/src/multiplayer-servers/monitoring/debugging.md
+++ b/src/multiplayer-servers/monitoring/debugging.md
@@ -1,0 +1,146 @@
+# Debugging game server integration
+
+This guide helps you diagnose common issues with game server integration, such as misconfigured environment variables, unexpected game server state, and allocation problems.
+
+## Use Vessels for integration and debugging
+
+Even if your game ultimately requires [Armadas](/multiplayer-servers/getting-started/glossary#armada), start with a [Vessel](/multiplayer-servers/getting-started/glossary#vessel) during integration and debugging. Vessels give you a single game server that you can restart directly from the UI, and container logs are visible in the UI without any additional setup. This makes the feedback loop much faster than working with Armadas. Once your integration works with a Vessel, test with Armadas as well before deploying to production, since there are differences in configuration that may require adjustments.
+
+## Viewing container logs
+
+Every container in your game server pod writes logs to `stdout` and `stderr`, which GameFabric collects automatically. There are two ways to access them.
+
+### Vessel UI
+
+If you are using a [Vessel](/multiplayer-servers/getting-started/glossary#vessel), logs for all containers (including sidecars) are available directly in the Vessel UI. Note that logs from previous container runs are not included — only logs from the current run are shown.
+
+::: warning
+The Vessel UI may struggle with game servers that produce high log volumes. For log-heavy servers, use the Grafana dashboards described below.
+:::
+
+### Grafana
+
+All game server logs, including those managed by Formations or Armadas, or those from restarted containers, can be found using the monitoring dashboards:
+
+1. Navigate to **Monitoring** in the GameFabric UI.
+1. Open the **Current Gameservers** dashboard.
+1. Click any matching pod name. This opens the **Gameserver Single Instance** dashboard.
+
+The **Gameserver Single Instance** dashboard shows all container logs, including all sidecar logs, automatically. There is nothing to select or configure.
+
+## Inspecting the game server object
+
+The Agones SDK exposes a local REST endpoint inside every game server pod. You can query it from within your container (for example, in an entrypoint script or a sidecar) to see the current game server state, addresses, ports, labels, and annotations:
+
+```bash
+curl "http://localhost:${AGONES_SDK_HTTP_PORT}/gameserver"
+```
+
+To pretty-print the JSON response, pipe to `jq` if available in your image:
+
+```bash
+curl "http://localhost:${AGONES_SDK_HTTP_PORT}/gameserver" | jq '.'
+```
+
+This endpoint is only accessible from within the pod. The `AGONES_SDK_HTTP_PORT` environment variable is always set in every container in the pod and defaults to `9358`.
+
+This is useful for verifying that your game server transitions through the expected lifecycle states (`Ready`, `Allocated`, `Shutdown`) and that labels and annotations are set correctly.
+
+## Checking environment variables
+
+Misconfigured environment variables are one of the most common issues. To verify that all required variables are set, print them from within your container (for example, in an entrypoint script or a sidecar):
+
+```bash
+env
+```
+
+::: warning
+The `env` command may not be available in minimal or distroless container images. Additionally, `env` prints every environment variable, including secrets such as `ALLOC_TOKEN`. Since the output appears in container logs, avoid running this in production or any environment where logs are shared or retained. If a secret is exposed in logs, rotate it afterward.
+:::
+
+## Using a debug sidecar
+
+If you cannot easily add diagnostic commands to your game server, you can run a lightweight sidecar container alongside it. The following example shows one approach that prints environment variables on start and polls the Agones SDK game server object every 10 seconds. This is only an example — you can build your own debug sidecar with different tooling or safer approaches that fit your needs.
+
+::: warning
+Because sidecar output appears in container logs, which may include secrets, use debug sidecars only in non-production environments or redact sensitive values before sending logs to shared systems.
+:::
+
+### Building the debug sidecar image
+
+Create the following two files and build the container image.
+
+The shell script (`debugger.sh`):
+
+```bash
+#!/usr/bin/env bash
+
+echo "hello from the debugger"
+echo
+echo "ENV"
+env
+
+echo
+echo "Agones:"
+
+while true; do
+  echo
+  curl "http://localhost:${AGONES_SDK_HTTP_PORT}/gameserver" \
+    | jq '.'
+  sleep 10
+done
+```
+
+The Dockerfile:
+
+```dockerfile
+# 1. Select an operating system.
+FROM ubuntu:24.04
+
+# 2. Pre-install requirements.
+RUN apt-get update \
+        && apt-get install -y gnupg ca-certificates curl jq \
+        && apt-get clean -y
+
+# 3. Prepare a working directory and permissions.
+RUN mkdir /app && chown 1000:1000 /app
+
+# 4. Copy the debugger entrypoint and make it executable.
+USER 1000
+COPY --chown=1000:1000 debugger.sh /app/debugger
+RUN chmod +x /app/debugger
+WORKDIR /app
+
+CMD ["/app/debugger"]
+```
+
+Build and push the image to your container registry. If you are building on macOS, specify the target platform explicitly:
+
+```bash
+docker build --platform linux/amd64 -t <your-registry>/debug-sidecar:1.0.0 .
+docker push <your-registry>/debug-sidecar:1.0.0
+```
+
+For more details on building container images, see [Building a container image](/multiplayer-servers/getting-started/building-a-container-image#create-a-dockerfile).
+
+### Adding the debug sidecar to your game server
+
+1. Navigate to your [Formation](/multiplayer-servers/getting-started/glossary#formation), [Vessel](/multiplayer-servers/getting-started/glossary#vessel), [ArmadaSet](/multiplayer-servers/getting-started/glossary#armadaset), or [Armada](/multiplayer-servers/getting-started/glossary#armada) configuration.
+1. In the **Sidecars** section, select **Create from scratch**.
+1. Set the container image to your debug sidecar image.
+1. Save your changes.
+
+For more details on adding custom sidecars, see [Sidecar Containers](/multiplayer-servers/architecture/sidecars#custom-sidecars).
+
+Once deployed, open the **Gameserver Single Instance** dashboard in [Monitoring](/multiplayer-servers/monitoring/introduction) and select the debug sidecar container to see the environment variables and game server object output.
+
+## Debugging the allocation flow
+
+If game servers are not being allocated as expected, increase the log verbosity of the [Allocation Sidecar](/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers):
+
+1. Set the `LOG_LEVEL` environment variable on the Allocation Sidecar container to `debug`.
+1. Check the Allocation Sidecar logs in the **Gameserver Single Instance** dashboard.
+
+At `debug` level, the Allocation Sidecar logs the full allocation payload from your matchmaker. At `info` level (the default), it logs registration events including the game server address, callback address, and configured [attributes](/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers#attributes).
+
+For the full list of Allocation Sidecar configuration options, see [Advanced configuration](/multiplayer-servers/multiplayer-services/server-allocation/automatically-registering-game-servers#advanced-configuration).

--- a/src/multiplayer-servers/monitoring/sidebar.json
+++ b/src/multiplayer-servers/monitoring/sidebar.json
@@ -14,6 +14,10 @@
     {
       "text": "Audit Logs",
       "link": "/monitoring/auditlogs"
+    },
+    {
+      "text": "Debugging",
+      "link": "/monitoring/debugging"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds a new **Debugging game server integration** page under Monitoring
- Adds a **Degraded** glossary entry explaining the synchronization state
- Updates all example Dockerfiles to `ubuntu:24.04` and removes `useradd` (uses uid 1000 directly)

## Context

This PR unifies and supersedes:
- #275 (debugging guide) — all review feedback addressed
- #217 (Armada states / troubleshooting) — replaced with a minimal glossary entry since the UI now shows `status.reason` directly on affected objects

## Changes

| File | Description |
|------|-------------|
| `src/multiplayer-servers/monitoring/debugging.md` | New end-to-end debugging guide |
| `src/multiplayer-servers/monitoring/sidebar.json` | Adds Debugging sidebar entry |
| `src/multiplayer-servers/getting-started/glossary.md` | Adds Degraded definition |
| `src/multiplayer-servers/getting-started/building-a-container-image.md` | Ubuntu 24.04, remove useradd |
| `src/multiplayer-servers/getting-started/quickstart.md` | Ubuntu 24.04, remove useradd |