### PR TITLE
docs: document Armada minReplicas zero-mode and fix validation rules

### DIFF
--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -1,5 +1,7 @@
 # Armada replicas and buffer
 
+These settings apply equally to Armadas and ArmadaSets. ArmadaSets configure them once and propagate the values to each per-region Armada. The rest of this page uses "Armada" for brevity.
+
 An Armada can spin up one game server, thousands of game servers, or anything in between, including no game servers as the special case of [Scaling Down](#scaling-down).
 The number of game servers running in each Region Type is determined by the Replicas and Buffer settings:
 
@@ -16,8 +18,10 @@ When configured too low, such as if not enough `Ready` game servers are availabl
 
 Replicas are the number of game servers running in any given state, from `Starting` to `Ready`, from `Allocated` to `Unhealthy`, `Shutdown` or `Error`.
 
-No matter the state of the game servers, the **Minimum Replicas** setting makes sure there are at least that many game servers running at any given time.
-If that is not the case, GameFabric spins up new game servers.
+The **Minimum Replicas** setting keeps at least that many game servers running at all times, regardless of their state.
+When the count falls below the minimum, GameFabric spins up new game servers to compensate.
+Setting Minimum Replicas to `0` is a special case: no static floor is enforced, and the Buffer Size becomes the effective minimum instead.
+See [Minimum replicas](#minimum-replicas) for guidance on choosing between the two modes.
 
 The **Maximum Replicas** setting makes sure no more game servers are started when the total number of game servers reaches that number.
 
@@ -30,10 +34,14 @@ This is important so players can find a game server quickly, without having to w
 
 When configuring an Armada, the following validation rules apply:
 
-- Minimum Replicas must be at least as big as the Buffer Size
-- Minimum Replicas must be smaller or equal to Maximum Replicas
+- Minimum Replicas must be `0` or greater.
+- Maximum Replicas must be `0` or greater.
+- Buffer Size must be greater than `0` when Maximum Replicas is greater than `0`.
+- Maximum Replicas must be greater than or equal to Buffer Size.
+- Maximum Replicas must be greater than or equal to Minimum Replicas.
+- If Minimum Replicas is greater than `0`, it must be greater than or equal to Buffer Size. Set it to `0` to defer the floor to the buffer instead (see [Minimum replicas](#minimum-replicas)).
 
-whereas <span class="nbsp">`0, 0, 0`</span> is considered <span class="nbsp">[Scaling Down](#scaling-down).</span>
+Setting all three values to `0` is a special case: see [Scaling Down](#scaling-down).
 
 ## Finding the right values
 
@@ -102,12 +110,22 @@ Frequently revisit and adjust the Minimum Replicas, Maximum Replicas, and Buffer
 
 ### Minimum replicas
 
-Choosing a value for the Minimum Replicas is mostly driven by the Buffer Size, as the Minimum Replicas must always be at least as high as the Buffer Size.
+Minimum Replicas has two modes depending on whether it is set to `0` or a positive value.
 
-The **recommended default** is to set the Minimum Replicas to the value of the Buffer Size.
+**Set to `0` (defer to buffer):**
+When Minimum Replicas is `0`, no static floor is enforced on the total replica count.
+The Buffer Size becomes the effective floor: the autoscaler maintains `bufferSize` ready servers, and the total count can fall below the buffer value once all those servers are `Allocated` and none remain in other states.
+Use this mode when you want the buffer alone to drive capacity and have no requirement to keep a fixed number of servers running at all times.
 
-In case of an upcoming release or launch, with the expectation of an instant high player count, the Minimum Replicas can be set to a higher value to ensure enough game servers are running initially to accommodate the expected load.
-It is vital to review and adjust the value after the initial peak has subsided, to avoid unnecessary costs.
+**Set to a positive value (static floor):**
+When Minimum Replicas is greater than `0`, GameFabric keeps at least that many game servers running in any state at all times — regardless of whether they are `Ready`, `Allocated`, or `Unhealthy`.
+The value must be at least as large as the Buffer Size and no larger than Maximum Replicas.
+
+The **recommended default** is to set Minimum Replicas to the same value as the Buffer Size.
+This aligns the static floor with the ready pool so the autoscaler never has to spin up extra game servers solely to satisfy the minimum.
+
+In case of an upcoming release or launch, with the expectation of an instant high player count, Minimum Replicas can be raised above the Buffer Size to pre-warm additional capacity.
+Review and lower the value once the peak has subsided to avoid unnecessary costs.
 
 ### Maximum replicas
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -30,7 +30,7 @@ This is important so players can find a game server quickly, without having to w
 
 ## Input validation
 
-When configuring an Armada, the following validation rules apply:
+When configuring an Armada or ArmadaSet, the following validation rules apply:
 
 - All three values must be `0` or greater.
 - Maximum Replicas must be at least as high as both Minimum Replicas and Buffer Size.

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -119,7 +119,7 @@ When Minimum Replicas is greater than `0`, GameFabric keeps at least that many g
 The value must be at least as large as the Buffer Size and no larger than Maximum Replicas.
 
 The **recommended default** is `0`: let the buffer drive ready capacity without adding a separate static floor.
-Use a positive value only when you have a specific reason to guarantee a minimum number of servers running regardless of demand — for example, pre-warming capacity ahead of a launch.
+Use a non-zero value only when you have a specific reason to guarantee a minimum number of servers running regardless of demand — for example, pre-warming capacity ahead of a launch.
 Review and lower the value once the peak has subsided to avoid unnecessary costs.
 
 ### Maximum replicas

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -17,7 +17,7 @@ When configured too low, such as if not enough `Ready` game servers are availabl
 Replicas are the number of game servers running in any given state, from `Starting` to `Ready`, from `Allocated` to `Unhealthy`, `Shutdown` or `Error`.
 
 The **Minimum Replicas** setting keeps at least that many game servers running at all times, regardless of their state.
-When the count falls below the minimum, GameFabric spins up new game servers to compensate.
+When the count falls below the minimum — for example, as game sessions terminate and servers shut down — GameFabric spins up new game servers to compensate.
 Setting Minimum Replicas to `0` is a special case: no static floor is enforced on total replicas, and the autoscaler targets the Buffer Size as the number of `Ready` servers instead.
 See [Minimum replicas](#minimum-replicas) for guidance on choosing between the two modes.
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -1,7 +1,5 @@
 # Armada replicas and buffer
 
-These settings apply equally to Armadas and ArmadaSets. ArmadaSets configure them once and propagate the values to each per-region Armada. The rest of this page uses "Armada" for brevity.
-
 An Armada can spin up one game server, thousands of game servers, or anything in between, including no game servers as the special case of [Scaling Down](#scaling-down).
 The number of game servers running in each Region Type is determined by the Replicas and Buffer settings:
 
@@ -34,12 +32,10 @@ This is important so players can find a game server quickly, without having to w
 
 When configuring an Armada, the following validation rules apply:
 
-- Minimum Replicas must be `0` or greater.
-- Maximum Replicas must be `0` or greater.
-- Buffer Size must be greater than `0` when Maximum Replicas is greater than `0`.
-- Maximum Replicas must be greater than or equal to Buffer Size.
-- Maximum Replicas must be greater than or equal to Minimum Replicas.
-- If Minimum Replicas is greater than `0`, it must be greater than or equal to Buffer Size. Set it to `0` to defer the floor to the buffer instead (see [Minimum replicas](#minimum-replicas)).
+- All three values must be `0` or greater.
+- Maximum Replicas must be at least as high as both Minimum Replicas and Buffer Size.
+- Buffer Size must be greater than `0` if Maximum Replicas is greater than `0`.
+- If Minimum Replicas is greater than `0`, it must be at least as high as Buffer Size. Set it to `0` to let the buffer act as the lower bound instead (see [Minimum replicas](#minimum-replicas)).
 
 Setting all three values to `0` is a special case: see [Scaling Down](#scaling-down).
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -18,7 +18,7 @@ Replicas are the number of game servers running in any given state, from `Starti
 
 The **Minimum Replicas** setting keeps at least that many game servers running at all times, regardless of their state.
 When the count falls below the minimum, GameFabric spins up new game servers to compensate.
-Setting Minimum Replicas to `0` is a special case: no static floor is enforced, and the Buffer Size becomes the effective minimum instead.
+Setting Minimum Replicas to `0` is a special case: no static floor is enforced on total replicas, and the autoscaler targets the Buffer Size as the number of `Ready` servers instead.
 See [Minimum replicas](#minimum-replicas) for guidance on choosing between the two modes.
 
 The **Maximum Replicas** setting makes sure no more game servers are started when the total number of game servers reaches that number.
@@ -109,9 +109,10 @@ Frequently revisit and adjust the Minimum Replicas, Maximum Replicas, and Buffer
 Minimum Replicas has two modes depending on whether it is set to `0` or a positive value.
 
 **Set to `0` (defer to buffer):**
-When Minimum Replicas is `0`, no static floor is enforced on the total replica count.
-The Buffer Size becomes the effective floor: the autoscaler maintains `bufferSize` ready servers, and the total count can fall below the buffer value once all those servers are `Allocated` and none remain in other states.
-Use this mode when you want the buffer alone to drive capacity and have no requirement to keep a fixed number of servers running at all times.
+When Minimum Replicas is `0`, no static floor is enforced on total replicas.
+The autoscaler targets the Buffer Size as the number of `Ready` servers — it spins up new servers whenever the `Ready` count drops below the buffer.
+Total replicas at any given time reflect both `Ready` and `Allocated` servers combined, so the count rises above the buffer as demand grows and falls back as servers shut down.
+Use this mode when you want the buffer alone to drive ready capacity and have no requirement to keep a fixed number of servers running at all times.
 
 **Set to a positive value (static floor):**
 When Minimum Replicas is greater than `0`, GameFabric keeps at least that many game servers running in any state at all times — regardless of whether they are `Ready`, `Allocated`, or `Unhealthy`.

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -54,7 +54,7 @@ There is **no recommended default**, as it depends on multiple factors specific 
 **Important factors to determine the Buffer Size:**
 
 1. **Game server startup time:**
-   
+
    Quicker startup times reduce the need for a large Buffer Size.
 
 2. **Game session duration:**
@@ -130,7 +130,7 @@ A Location can hold multiple different Armadas, each with different Resource Req
 **Important factors to determine the Maximum Replicas:**
 
 1. **Available resources:**
-   
+
    The total CPU and Memory available on the Locations associated with the Region Type define the technical limit for the Maximum Replicas.
 
 2. **Game server Resource Requests:**
@@ -143,7 +143,7 @@ A Location can hold multiple different Armadas, each with different Resource Req
    An open world game mode requires more resources than a town server that only handles social interactions, but both may end up on the same Locations.
 
 4. **Overcommitment strategy:**
-   
+
    Not all game servers are `Allocated` at the same time, some stay `Ready` for a while.
    Intentional overcommitment is generally recommended to improve overall utilization.
    The challenge is managing allocations when multiple Armadas share the same underlying resources.
@@ -195,15 +195,15 @@ Whether through player peaks, due to bugs or DDoS attacks, always choose a limit
 The Buffer Size can be set to a fixed value as previously explained, or it can be dynamically adjusted based on the current player demand using
 the `Dynamic Buffer` option.
 
-When dynamic mode is enabled, GameFabric adjusts Buffer Size at two levels.  
-First, it updates the baseline Buffer Size for each region type based on overall demand trends.  
+When dynamic mode is enabled, GameFabric adjusts Buffer Size at two levels.
+First, it updates the baseline Buffer Size for each region type based on overall demand trends.
 Then, for each Site, it applies an additional local adjustment using site-specific signals such as `Ready` and `Allocated` game server counts, startup time, and player demand.
 This allows for a more responsive and cost-effective approach to managing the Buffer Size, as it can automatically scale up or down based on the current trends.
 
 ::: info
 
-Dynamic Buffer needs at least 24 hours of allocation data to determine a suitable Buffer Size, and it can take up to 48 hours to stabilize on a good 
-Buffer Size after being enabled. During this time, it is recommended to closely monitor the behavior of the Buffer Size and its impact on player experience 
+Dynamic Buffer needs at least 24 hours of allocation data to determine a suitable Buffer Size, and it can take up to 48 hours to stabilize on a good
+Buffer Size after being enabled. During this time, it is recommended to closely monitor the behavior of the Buffer Size and its impact on player experience
 and costs, and adjust the configuration as needed.
 
 It is expected that smaller player numbers (<50 CCU) cause more fluctuations in the Buffer Size, as there is less data to base the adjustments on,
@@ -220,7 +220,7 @@ experience and costs, and adjust the configuration as needed.
 
 ### Enabling dynamic buffer
 
-To enable the Dynamic Buffer, toggle the `Dynamic Buffer` option on a `Region - Type`. You will be asked to confirm that you understand 
+To enable the Dynamic Buffer, toggle the `Dynamic Buffer` option on a `Region - Type`. You will be asked to confirm that you understand
 the implications of enabling this feature.
 
 Once enabled GameFabric starts to control the Buffer Size, and any manual adjustments to the Buffer Size are be overridden by GameFabric's adjustments
@@ -239,12 +239,12 @@ The slider configures the cost-efficiency of the Buffer Size adjustments, with a
 
 The slider configuration can generally be categorized as follows:
 
-- **Cost-Efficient (1-3)**: The number of `Ready` game servers is kept to a minimum and scaling up happens more slowly which can result in game servers not 
+- **Cost-Efficient (1-3)**: The number of `Ready` game servers is kept to a minimum and scaling up happens more slowly which can result in game servers not
   being available during allocation peaks.
 - **Balanced (4-11)**: A balance between cost and availability is maintained, with a moderate approach to scaling game servers.
 - **Availability-Focused (12-15)**: The number of `Ready` game servers is increased to ensure availability during allocation peaks, with faster scaling up of game servers.
 
-::: info 
+::: info
 
 The Buffer Size calculated can be constrained by the Minimum Replicas. If this is observed, it is recommended to increase the Minimum Replicas to allow
 for a larger Buffer Size.

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -118,10 +118,8 @@ Use this mode when you want the buffer alone to drive ready capacity and have no
 When Minimum Replicas is greater than `0`, GameFabric keeps at least that many game servers running in any state at all times — regardless of whether they are `Ready`, `Allocated`, or `Unhealthy`.
 The value must be at least as large as the Buffer Size and no larger than Maximum Replicas.
 
-The **recommended default** is to set Minimum Replicas to the same value as the Buffer Size.
-This aligns the static floor with the ready pool so the autoscaler never has to spin up extra game servers solely to satisfy the minimum.
-
-In case of an upcoming release or launch, with the expectation of an instant high player count, Minimum Replicas can be raised above the Buffer Size to pre-warm additional capacity.
+The **recommended default** is `0`: let the buffer drive ready capacity without adding a separate static floor.
+Use a positive value only when you have a specific reason to guarantee a minimum number of servers running regardless of demand — for example, pre-warming capacity ahead of a launch.
 Review and lower the value once the peak has subsided to avoid unnecessary costs.
 
 ### Maximum replicas


### PR DESCRIPTION
## Summary
Documents the `minReplicas` scaling field for Armadas and ArmadaSets in the existing [Replicas and Buffer Size](src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md) page.
## Changes
- **Applicability note**: states up front that these settings apply equally to both Armadas and ArmadaSets.
- **Minimum/maximum replicas section**: introduces the `minReplicas = 0` special case with a forward reference to the guidance section.
- **Input validation section**: replaces the previous incomplete and partially incorrect rules with the full set of constraints, including the `0`-as-lower-bound exception.
- **Minimum replicas guidance**: expands from 4 lines to a two-mode explanation — `0` (defer to buffer, no static floor) vs. a positive value (static floor, must be ≥ buffer) — plus the pre-warming advice for launches.
- **Simplifies validation list wording**: removes engineering-style phrasing ("greater than or equal to") in favour of plain English ("at least as high as"), collapsing 6 bullets to 4.