### PR TITLE
docs(monitoring): add audit log exports guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ If you add new tooling (linters/tests), update this file.
 - Build output: `.vitepress/dist`
 
 ## Commands (build / lint / test)
+
+> **Tooling rule:** Use `yarn` directly if it is available on your system. If yarn (or npm) is not installed, use the Docker-based equivalents via `make` instead.
+
 ### Install
 - `corepack enable && yarn install`
   - CI enables Corepack before install.
@@ -18,13 +21,13 @@ If you add new tooling (linters/tests), update this file.
 
 ### Local development
 - Dev server: `yarn docs:dev` (binds `0.0.0.0`, default `http://localhost:5173`)
-- Container dev server:
+- Container dev server (no local yarn/npm required):
   - Build image: `make image` (uses `.dev/Dockerfile`)
   - Run: `make dev` (mounts `./src` into the container)
 
 ### Build / preview
-- Build: `yarn docs:build`
-- Preview build: `yarn docs:serve`
+- Build: `yarn docs:build` — or `make build` if yarn is not installed
+- Preview build: `yarn docs:serve` — or `make serve` if yarn is not installed
 
 ### Linting (current)
 - No ESLint/Prettier/formatter configured.
@@ -37,14 +40,14 @@ If you add new tooling (linters/tests), update this file.
 ### Tests (current)
 - No unit/integration test runner configured (`vitest`/`jest` not present).
 - Validation is primarily:
-  - `yarn docs:build` to catch build-time failures
-  - `yarn docs:dev` or `yarn docs:serve` for manual verification
+  - `yarn docs:build` (or `make build`) to catch build-time failures
+  - `yarn docs:dev` (or `make dev`) for manual verification
 
-### “Single test” guidance
-- There is no “run one test” command today.
+### "Single test" guidance
+- There is no "run one test" command today.
 - Closest equivalents:
-  - Validate one page visually: `yarn docs:dev` then navigate to the route.
-  - Catch build regressions quickly: `yarn docs:build`.
+  - Validate one page visually: `yarn docs:dev` (or `make dev`) then navigate to the route.
+  - Catch build regressions quickly: `yarn docs:build` (or `make build`).
 - If a test runner is added later (recommended: `vitest`), also document:
   - `yarn test` (full suite)
   - `yarn vitest -t "test name"` (single test)
@@ -60,8 +63,8 @@ When adding docs:
 - Update the nearest `sidebar.json` and include an `order` field.
 
 ## Validation checklist
-- Build still passes: `yarn docs:build`.
-- Spot-check changed pages in `yarn docs:dev`.
+- Build still passes: `yarn docs:build` (or `make build`).
+- Spot-check changed pages in `yarn docs:dev` (or `make dev`).
 - Ensure `sidebar.json` stays valid JSON and `order` values remain unique.
 - Verify new/changed links and images render as expected.
 
@@ -137,10 +140,7 @@ For OpenAPI pages, follow the existing pattern (see `README.md`):
 ## Safety notes for agents
 - Don't add new dependencies unless necessary for docs rendering.
 - Avoid touching large image assets unless requested (big diffs).
-- After code changes, verify the build passes:
-  - Preferred: `yarn docs:build` (if Yarn/Corepack is available locally)
-  - Fallback: `docker run --rm gamefabric-docs-dev yarn docs:build` (requires `make image` first)
-  - No tooling: note in PR that build was not verified locally
+- After code changes, verify the build passes: `yarn docs:build` (or `make build` if yarn is not installed).
 
 ## Copilot rules
 

--- a/src/multiplayer-servers/monitoring/audit-log-exports.md
+++ b/src/multiplayer-servers/monitoring/audit-log-exports.md
@@ -1,6 +1,6 @@
 # Audit log exports
 
-Audit log exports let you continuously push audit logs to an external S3-compatible storage location. This is useful for long-term retention, compliance archiving, or feeding audit data into your own SIEM or analytics pipeline.
+Audit log exports let you continuously push audit logs to an external S3-compatible storage location. This is useful for long-term retention, compliance archiving, or feeding audit data into your own SIEM (Security Information and Event Management) or analytics pipeline.
 
 ::: info Delivery delay
 To guarantee that all audit log events are captured, GameFabric intentionally delays delivery by a couple of minutes. Events generated close to the current time may not yet appear in the export destination. This applies both to continuous delivery and to the final batch written when an export store is disabled.
@@ -92,3 +92,4 @@ To delete an export store, follow these steps.
 1. Open the **Manage Exports** drawer.
 1. Open the action menu (⋮) for the export store.
 1. Click **Delete** and confirm the action in the dialog.
+

--- a/src/multiplayer-servers/monitoring/audit-log-exports.md
+++ b/src/multiplayer-servers/monitoring/audit-log-exports.md
@@ -15,12 +15,13 @@ See [Permissions](#permissions) for the full list of required capabilities.
 
 The following permissions are required to manage audit log exports. A user must belong to a `group` with a `role` that includes the relevant permissions.
 
-| Action | Resource | Verb | API group |
-|---|---|---|---|
-| View exports | `exportstores` | `GET` | `audit` |
-| Create exports | `exportstores` | `POST` | `audit` |
-| Edit exports | `exportstores` | `PATCH` | `audit` |
-| Delete exports | `exportstores` | `DELETE` | `audit` |
+| Action         | Resource       | Verb     | API group |
+|----------------|----------------|----------|-----------|
+| View exports   | `exportstores` | `GET`    | `audit`   |
+| Create exports | `exportstores` | `POST`   | `audit`   |
+| Edit exports   | `exportstores` | `PATCH`  | `audit`   |
+| Delete exports | `exportstores` | `DELETE` | `audit`   |
+
 
 See [Editing Permissions](/multiplayer-servers/authentication/editing-permissions) for more information.
 
@@ -49,15 +50,15 @@ To add a new export destination, follow these steps.
 
 The following fields are available:
 
-| Field | Required | Description |
-|---|---|---|
-| **Name** | Yes | A unique identifier for this export store. Must be lowercase alphanumeric, and may contain `-` or `.`. Maximum 63 characters. |
-| **Endpoint** | No | The S3-compatible endpoint URL. Defaults to `https://s3.amazonaws.com`. Use a custom value for providers such as Cloudflare R2. |
-| **Region** | Yes | The storage region (for example, `eu-west-1`). Use `auto` for providers that do not require a region. |
-| **Bucket** | Yes | The name of the S3 bucket to deliver logs into. |
-| **Object path / prefix** | No | An optional key prefix (folder) prepended to every uploaded object. |
-| **Access Key ID** | Yes | The access key ID for HMAC credential authentication. |
-| **Secret Access Key** | Yes | The secret access key for HMAC credential authentication. |
+| Field                    | Required | Description                                                                                                                     |
+|--------------------------|----------|---------------------------------------------------------------------------------------------------------------------------------|
+| **Name**                 | Yes      | A unique identifier for this export store. Must be lowercase alphanumeric, and may contain `-` or `.`. Maximum 63 characters.   |
+| **Endpoint**             | No       | The S3-compatible endpoint URL. Defaults to `https://s3.amazonaws.com`. Use a custom value for providers such as Cloudflare R2. |
+| **Region**               | Yes      | The storage region (for example, `eu-west-1`). Use `auto` for providers that do not require a region.                           |
+| **Bucket**               | Yes      | The name of the S3 bucket to deliver logs into.                                                                                 |
+| **Object path / prefix** | No       | An optional key prefix (folder) prepended to every uploaded object.                                                             |
+| **Access Key ID**        | Yes      | The access key ID for HMAC credential authentication.                                                                           |
+| **Secret Access Key**    | Yes      | The secret access key for HMAC credential authentication.                                                                       |
 
 ## Edit an export store
 

--- a/src/multiplayer-servers/monitoring/audit-log-exports.md
+++ b/src/multiplayer-servers/monitoring/audit-log-exports.md
@@ -1,0 +1,94 @@
+# Audit log exports
+
+Audit log exports let you continuously push audit logs to an external S3-compatible storage location. This is useful for long-term retention, compliance archiving, or feeding audit data into your own SIEM or analytics pipeline.
+
+::: info Delivery delay
+To guarantee that all audit log events are captured, GameFabric intentionally delays delivery by a couple of minutes. Events generated close to the current time may not yet appear in the export destination. This applies both to continuous delivery and to the final batch written when an export store is disabled.
+:::
+
+::: info Availability
+The **Manage Exports** button is only visible to users who have the `GET` permission for the `exportstores` resource in the `audit` API group.
+See [Permissions](#permissions) for the full list of required capabilities.
+:::
+
+## Permissions
+
+The following permissions are required to manage audit log exports. A user must belong to a `group` with a `role` that includes the relevant permissions.
+
+| Action | Resource | Verb | API group |
+|---|---|---|---|
+| View exports | `exportstores` | `GET` | `audit` |
+| Create exports | `exportstores` | `POST` | `audit` |
+| Edit exports | `exportstores` | `PATCH` | `audit` |
+| Delete exports | `exportstores` | `DELETE` | `audit` |
+
+See [Editing Permissions](/multiplayer-servers/authentication/editing-permissions) for more information.
+
+## Export stores
+
+An **export store** is the configuration object that targets one S3-compatible bucket. GameFabric continuously delivers batches of audit log events to the configured bucket.
+
+Each export store has a status that reflects its current operational state:
+
+- **Active** — Delivery is running normally.
+- **Suspended** — Delivery is paused. GameFabric drains any pending events before transitioning to this state.
+- **Error** — Delivery has failed. Hover over the error indicator next to the export store name to see the error message.
+
+## Open the exports drawer
+
+To manage your export stores, navigate to **Audit Logs** and click the **Manage Exports** button in the page header. A summary tag next to the button shows how many exports are active out of the total configured.
+
+## Create an export store
+
+To add a new export destination, follow these steps.
+
+1. Open the **Manage Exports** drawer.
+1. Click **Add Export**.
+1. Fill in the required fields described in the table below.
+1. Click **Add Export** to save.
+
+The following fields are available:
+
+| Field | Required | Description |
+|---|---|---|
+| **Name** | Yes | A unique identifier for this export store. Must be lowercase alphanumeric, and may contain `-` or `.`. Maximum 63 characters. |
+| **Endpoint** | No | The S3-compatible endpoint URL. Defaults to `https://s3.amazonaws.com`. Use a custom value for providers such as Cloudflare R2. |
+| **Region** | Yes | The storage region (for example, `eu-west-1`). Use `auto` for providers that do not require a region. |
+| **Bucket** | Yes | The name of the S3 bucket to deliver logs into. |
+| **Object path / prefix** | No | An optional key prefix (folder) prepended to every uploaded object. |
+| **Access Key ID** | Yes | The access key ID for HMAC credential authentication. |
+| **Secret Access Key** | Yes | The secret access key for HMAC credential authentication. |
+
+## Edit an export store
+
+To change the configuration of an existing export store, follow these steps.
+
+1. Open the **Manage Exports** drawer.
+1. Find the export store you want to change and open its action menu (⋮).
+1. Click **Edit**.
+1. Update the fields as needed, then click **Save Changes**.
+
+::: info Secret access key
+The secret access key is never displayed after creation. To rotate the key, open the edit form and type the new value into the **Secret Access Key** field.
+:::
+
+## Enable or disable an export store
+
+Disabling an export store pauses delivery. GameFabric does not transition the status to **Suspended** immediately — it first flushes all pending events to the bucket, including any that fall within the delivery delay window. This drain may take a few minutes. During this time the status remains **Active**; it changes to **Suspended** only after the drain is complete.
+
+To toggle an export store, follow these steps.
+
+1. Open the **Manage Exports** drawer.
+1. Open the action menu (⋮) for the export store.
+1. Click the **Active / Disabled** toggle to change its state.
+1. Confirm the action in the dialog that appears.
+
+## Delete an export store
+
+Deleting an export store permanently removes the configuration. Logs already delivered to the bucket are not affected.
+
+To delete an export store, follow these steps.
+
+1. Open the **Manage Exports** drawer.
+1. Open the action menu (⋮) for the export store.
+1. Click **Delete** and confirm the action in the dialog.

--- a/src/multiplayer-servers/monitoring/auditlogs.md
+++ b/src/multiplayer-servers/monitoring/auditlogs.md
@@ -3,7 +3,7 @@
 Audit logs record every action taken in your GameFabric installation, including who made the change, which resource was affected, and whether the operation succeeded. Use audit logs to investigate incidents, satisfy compliance requirements, or track configuration drift.
 
 ::: info Data availability
-Audit logs may be delayed by up to 2 minutes due to collection and processing pipelines.
+Audit logs may be delayed by a couple of minutes due to collection and processing pipelines.
 :::
 
 To access audit logs, click **Audit Logs** in the sidebar.

--- a/src/multiplayer-servers/monitoring/auditlogs.md
+++ b/src/multiplayer-servers/monitoring/auditlogs.md
@@ -1,15 +1,34 @@
-# Audit Logs
+# Audit logs
 
-Each GameFabric installation has an own solution for audit logs.
+Audit logs record every action taken in your GameFabric installation, including who made the change, which resource was affected, and whether the operation succeeded. Use audit logs to investigate incidents, satisfy compliance requirements, or track configuration drift.
 
 ::: info Data availability
 Audit logs may be delayed by up to 2 minutes due to collection and processing pipelines.
 :::
 
-To access it, click on "Audit Logs".
+To access audit logs, click **Audit Logs** in the sidebar.
+
 ![Screenshot of the Monitoring sidebar in the GameFabric interface](images/sidebar.png)
 
 ## Permissions
 
 To access audit logs, a user must belong to a `group` with a `role` that has the `GET` permission for the `logs` resource.
 See the [Editing Permissions](/multiplayer-servers/authentication/editing-permissions) guide for more information.
+
+## Filtering and searching
+
+The audit log view provides several ways to narrow results. Use the toolbar to:
+
+- Search by **Entity ID** or **Editor**.
+- Filter by **Operation** (`create`, `delete`, `update`, `partial update`), **Environment**, or **Entity type**.
+- Select a **time range** with the time range picker.
+- Toggle **Include automated** to show or hide events from automated system actors.
+- Change the **sort direction** to view oldest or newest events first.
+
+Click any event row to expand it and view the full request and response payload.
+
+## Exporting audit logs
+
+GameFabric can continuously push audit logs to an external S3-compatible storage location. This enables long-term retention and integration with external compliance or analytics tools.
+
+For setup and configuration instructions, see [Audit log exports](/multiplayer-servers/monitoring/audit-log-exports).

--- a/src/multiplayer-servers/monitoring/sidebar.json
+++ b/src/multiplayer-servers/monitoring/sidebar.json
@@ -16,6 +16,10 @@
       "link": "/monitoring/auditlogs"
     },
     {
+      "text": "Audit log exports",
+      "link": "/monitoring/audit-log-exports"
+    },
+    {
       "text": "Debugging",
       "link": "/monitoring/debugging"
     }

--- a/src/multiplayer-servers/monitoring/sidebar.json
+++ b/src/multiplayer-servers/monitoring/sidebar.json
@@ -16,7 +16,7 @@
       "link": "/monitoring/auditlogs"
     },
     {
-      "text": "Audit log exports",
+      "text": "Audit Log Exports",
       "link": "/monitoring/audit-log-exports"
     },
     {


### PR DESCRIPTION
## Summary
Adds documentation for the managed audit log exports feature.
### Changes
- **New page** `src/multiplayer-servers/monitoring/audit-log-exports.md`
  Covers export stores, permissions, create/edit/delete/enable/disable flows,
  the delivery delay guarantee, and the drain-before-suspend behaviour when disabling.
- **Updated** `auditlogs.md`
  Expanded with a filtering/searching overview and a reference to the new exports page.
- **Updated** `sidebar.json`
  Added Audit log exports entry under Monitoring.
- **Updated** `AGENTS.md`
  Added tooling rule: use `yarn` when available; fall back to `make`/Docker when yarn/npm is not installed.
### Validation
Build verified locally via `make build` (passes clean).