### PR TITLE
docs: clarify that allocation speed is infrastructure-agnostic

### DIFF
--- a/src/multiplayer-servers/architecture/capacity-types.md
+++ b/src/multiplayer-servers/architecture/capacity-types.md
@@ -26,6 +26,7 @@ Key characteristics:
 - **Powered by GCP**: Built on Google Cloud Platform's high-performance infrastructure, utilizing a specialized selection of machine types optimized for GameFabric workloads.
 - **Integrated billing**: All costs are billed through GameFabric.
 - **Density**: Supports up to 100 game servers per node.
+- **Node autoscaling**: GameFabric automatically adjusts the number of nodes within a cloud Location based on game server demand — scaling up when more capacity is needed and scaling back down to save costs.
 
 To provision GameFabric Cloud capacity, see [GameFabric Cloud](/multiplayer-servers/getting-started/gamefabric-cloud).
 
@@ -46,6 +47,7 @@ Key characteristics:
 - **Multi-cloud support**: Supports Google Cloud Platform, Amazon Web Services, and Microsoft Azure with full machine type flexibility.
 - **Separate billing**: Cloud costs are billed directly by your cloud provider, preserving any negotiated rates or committed-use discounts.
 - **Density**: Supports up to 100 game servers per node.
+- **Node autoscaling**: GameFabric automatically adjusts the number of nodes based on game server demand — scaling up when more capacity is needed and scaling back down to save costs.
 
 To set up BYOC, see [Configuring your Cloud Provider](/multiplayer-servers/getting-started/cloud-provider-setup).
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -30,7 +30,7 @@ This is important so players can find a game server quickly, without having to w
 
 Allocation speed is independent of the underlying infrastructure. Whether game servers run on bare metal or cloud, the Allocator assigns a `Ready` server from the buffer pool instantly. The buffer is equally important on both infrastructure types: without enough `Ready` servers, players wait for a new server to start up regardless of the hardware underneath.
 
-In cloud environments, GameFabric autoscales the number of Nodes to match demand — scaling up when more capacity is needed and scaling back down to save costs. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new capacity comes online in the background.
+In cloud environments, GameFabric autoscales the number of nodes to match demand — scaling up when more capacity is needed and scaling back down to save costs. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new capacity comes online in the background.
 
 ## Input validation
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -30,7 +30,7 @@ This is important so players can find a game server quickly, without having to w
 
 Allocation speed is independent of the underlying infrastructure. Whether game servers run on bare metal or cloud, the Allocator assigns a `Ready` server from the buffer pool instantly. The buffer is equally important on both infrastructure types: without enough `Ready` servers, players wait for a new server to start up regardless of the hardware underneath.
 
-On cloud, GameFabric autoscales the number of Nodes to match demand -- scaling up when more capacity is needed and scaling back down to save costs. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new capacity comes online behind the scenes.
+In cloud environments, GameFabric autoscales the number of Nodes to match demand — scaling up when more capacity is needed and scaling back down to save costs. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new capacity comes online in the background.
 
 ## Input validation
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -30,7 +30,7 @@ This is important so players can find a game server quickly, without having to w
 
 Allocation speed is independent of the underlying [capacity type](/multiplayer-servers/architecture/capacity-types). Whether game servers run on bare metal or cloud, allocation draws from the pool of `Ready` servers in the buffer. When you use the [Allocator](/multiplayer-servers/getting-started/glossary#allocator), it assigns a `Ready` server instantly. The buffer is equally important on all capacity types: without enough `Ready` servers, players wait for a new server to start up.
 
-In cloud environments, GameFabric autoscales the number of nodes to match demand (see [GameFabric Cloud](/multiplayer-servers/architecture/capacity-types#gamefabric-cloud) and [BYOC](/multiplayer-servers/architecture/capacity-types#byoc)). This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new nodes come online in the background.
+In cloud environments, GameFabric autoscales the number of nodes to match demand (see [GameFabric Cloud](/multiplayer-servers/architecture/capacity-types#gamefabric-cloud) and [Bring Your Own Cloud (BYOC)](/multiplayer-servers/architecture/capacity-types#byoc)). This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new nodes come online in the background.
 
 ## Input validation
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -28,9 +28,9 @@ The **Maximum Replicas** setting makes sure no more game servers are started whe
 The Buffer Size is the [approximate](#buffer-size-value) number of game servers that are kept in the `Ready` state, waiting to get `Allocated`.
 This is important so players can find a game server quickly, without having to wait for a new game server to start up.
 
-Allocation speed is independent of the underlying infrastructure. Whether game servers run on bare metal or cloud, the Allocator assigns a `Ready` server from the buffer pool instantly. The buffer is equally important on both infrastructure types: without enough `Ready` servers, players wait for a new server to start up regardless of the hardware underneath.
+Allocation speed is independent of the underlying [capacity type](/multiplayer-servers/architecture/capacity-types). Whether game servers run on bare metal or cloud, allocation draws from the pool of `Ready` servers in the buffer. When you use the [Allocator](/multiplayer-servers/getting-started/glossary#allocator), it assigns a `Ready` server instantly. The buffer is equally important on all capacity types: without enough `Ready` servers, players wait for a new server to start up.
 
-In cloud environments, GameFabric autoscales the number of nodes to match demand — scaling up when more capacity is needed and scaling back down to save costs. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new capacity comes online in the background.
+In cloud environments, GameFabric [autoscales the number of nodes](/multiplayer-servers/architecture/capacity-types#gamefabric-cloud) to match demand. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new nodes come online in the background.
 
 ## Input validation
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -30,7 +30,7 @@ This is important so players can find a game server quickly, without having to w
 
 Allocation speed is independent of the underlying [capacity type](/multiplayer-servers/architecture/capacity-types). Whether game servers run on bare metal or cloud, allocation draws from the pool of `Ready` servers in the buffer. When you use the [Allocator](/multiplayer-servers/getting-started/glossary#allocator), it assigns a `Ready` server instantly. The buffer is equally important on all capacity types: without enough `Ready` servers, players wait for a new server to start up.
 
-In cloud environments, GameFabric [autoscales the number of nodes](/multiplayer-servers/architecture/capacity-types#gamefabric-cloud) to match demand. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new nodes come online in the background.
+In cloud environments, GameFabric autoscales the number of nodes to match demand (see [GameFabric Cloud](/multiplayer-servers/architecture/capacity-types#gamefabric-cloud) and [BYOC](/multiplayer-servers/architecture/capacity-types#byoc)). This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new nodes come online in the background.
 
 ## Input validation
 

--- a/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
+++ b/src/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer.md
@@ -28,6 +28,10 @@ The **Maximum Replicas** setting makes sure no more game servers are started whe
 The Buffer Size is the [approximate](#buffer-size-value) number of game servers that are kept in the `Ready` state, waiting to get `Allocated`.
 This is important so players can find a game server quickly, without having to wait for a new game server to start up.
 
+Allocation speed is independent of the underlying infrastructure. Whether game servers run on bare metal or cloud, the Allocator assigns a `Ready` server from the buffer pool instantly. The buffer is equally important on both infrastructure types: without enough `Ready` servers, players wait for a new server to start up regardless of the hardware underneath.
+
+On cloud, GameFabric autoscales the number of Nodes to match demand -- scaling up when more capacity is needed and scaling back down to save costs. This does not affect the allocation path. With the right buffer configuration, there are always enough `Ready` servers available to handle allocation requests while new capacity comes online behind the scenes.
+
 ## Input validation
 
 When configuring an Armada or ArmadaSet, the following validation rules apply:

--- a/src/multiplayer-servers/multiplayer-services/scaling.md
+++ b/src/multiplayer-servers/multiplayer-services/scaling.md
@@ -13,6 +13,7 @@ Every Armada is configured with three core scaling parameters per Region Type:
 
 These values determine how quickly players find a game server and how much idle capacity is maintained.
 Getting them right depends on game server startup time, session duration, and expected concurrent users.
+The buffer is equally important on bare metal and cloud: allocation always draws from the pool of `Ready` servers, regardless of the underlying infrastructure.
 
 For detailed guidance, including examples and input validation rules, see [Replicas and buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer).
 

--- a/src/multiplayer-servers/multiplayer-services/scaling.md
+++ b/src/multiplayer-servers/multiplayer-services/scaling.md
@@ -13,7 +13,7 @@ Every Armada is configured with three core scaling parameters per Region Type:
 
 These values determine how quickly players find a game server and how much idle capacity is maintained.
 Getting them right depends on game server startup time, session duration, and expected concurrent users.
-The buffer is equally important on bare metal and cloud: allocation always draws from the pool of `Ready` servers, regardless of the underlying infrastructure.
+The buffer is equally important on all [capacity types](/multiplayer-servers/architecture/capacity-types): allocation always draws from the pool of `Ready` servers, regardless of the underlying infrastructure.
 
 For detailed guidance, including examples and input validation rules, see [Replicas and buffer size](/multiplayer-servers/multiplayer-services/armada-replicas-and-buffer).
 


### PR DESCRIPTION
## Summary

Clarifies in the scaling and buffer documentation that allocation speed is
the same on bare metal and cloud, and that the buffer is equally important
on all capacity types.

## Changes

- **armada-replicas-and-buffer.md**: Added two paragraphs to the "Buffer size"
  section explaining that allocation is instant regardless of capacity type,
  and that cloud node autoscaling does not affect the allocation path.
- **scaling.md**: Added a sentence reinforcing that the buffer matters on all
  capacity types.
- **capacity-types.md**: Added "Node autoscaling" as a key characteristic for
  both GameFabric Cloud and BYOC sections.