### PR TITLE
docs(monitoring): add glossary entry for export store

### DIFF
--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -121,7 +121,7 @@ Capacity is managed on a per Environment basis via [Regions](#region).
 
 ## Export Store
 
-An export store is a configuration object that targets one S3-compatible bucket for continuous delivery of [audit log](/multiplayer-servers/monitoring/auditlogs) events. Each export store has a status: **Active**, **Suspended**, or **Error**.
+An export store is a configuration object that targets one S3-compatible bucket for continuous delivery of [audit logs](/multiplayer-servers/monitoring/auditlogs) events. Each export store has a status: **Active**, **Suspended**, or **Error**.
 
 See [Audit log exports](/multiplayer-servers/monitoring/audit-log-exports) for setup and configuration instructions.
 

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -119,6 +119,12 @@ Alongside the [RBAC](#rbac) features, it also allows limiting the access to cert
 
 Capacity is managed on a per Environment basis via [Regions](#region).
 
+## Export Store
+
+An export store is a configuration object that targets one S3-compatible bucket for continuous delivery of [audit log](/multiplayer-servers/monitoring/auditlogs) events. Each export store has a status: **Active**, **Suspended**, or **Error**.
+
+See [Audit log exports](/multiplayer-servers/monitoring/audit-log-exports) for setup and configuration instructions.
+
 ## Fleet
 
 A Fleet is a set of warm GameServers that are available to be allocated from.

--- a/src/multiplayer-servers/getting-started/glossary.md
+++ b/src/multiplayer-servers/getting-started/glossary.md
@@ -121,7 +121,7 @@ Capacity is managed on a per Environment basis via [Regions](#region).
 
 ## Export Store
 
-An export store is a configuration object that targets one S3-compatible bucket for continuous delivery of [audit logs](/multiplayer-servers/monitoring/auditlogs) events. Each export store has a status: **Active**, **Suspended**, or **Error**.
+An export store is a configuration object that targets one S3-compatible bucket for continuous delivery of [audit log events](/multiplayer-servers/monitoring/auditlogs). Each export store has a status: **Active**, **Suspended**, or **Error**.
 
 See [Audit log exports](/multiplayer-servers/monitoring/audit-log-exports) for setup and configuration instructions.
 


### PR DESCRIPTION
## Summary

Follow-up to #296. Adds a glossary entry for the "Export Store" concept introduced by the audit log exports page.

The term appears as an entity type in audit log events themselves (e.g., "ExportStore created"), so a glossary entry helps users understand what it refers to when reviewing their logs.

### Changes

- **glossary.md** — Add "Export Store" entry (alphabetically between Environment and Fleet) describing the concept and linking to the exports guide.

### Validation

Markdown-only change (text). CI will confirm build.